### PR TITLE
[feat] 사용자 로그인 유즈케이스 구현 준비

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,15 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // HTTP CLIENT
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.1")
+    implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/org/recordy/server/auth/domain/Auth.java
+++ b/src/main/java/org/recordy/server/auth/domain/Auth.java
@@ -11,6 +11,5 @@ public class Auth {
     private String id;
     private AuthPlatform platform;
     private AuthToken token;
-    private AuthStatus status;
     private User user;
 }

--- a/src/main/java/org/recordy/server/auth/domain/Auth.java
+++ b/src/main/java/org/recordy/server/auth/domain/Auth.java
@@ -1,0 +1,12 @@
+package org.recordy.server.auth.domain;
+
+import lombok.Getter;
+
+@Getter
+public class Auth {
+
+    private String id;
+    private AuthPlatform platform;
+    private AuthToken token;
+    private AuthStatus status;
+}

--- a/src/main/java/org/recordy/server/auth/domain/Auth.java
+++ b/src/main/java/org/recordy/server/auth/domain/Auth.java
@@ -1,8 +1,10 @@
 package org.recordy.server.auth.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Builder
 @Getter
 public class Auth {

--- a/src/main/java/org/recordy/server/auth/domain/Auth.java
+++ b/src/main/java/org/recordy/server/auth/domain/Auth.java
@@ -2,14 +2,11 @@ package org.recordy.server.auth.domain;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.recordy.server.user.domain.User;
 
 @Builder
 @Getter
 public class Auth {
 
-    private String id;
     private AuthPlatform platform;
     private AuthToken token;
-    private User user;
 }

--- a/src/main/java/org/recordy/server/auth/domain/Auth.java
+++ b/src/main/java/org/recordy/server/auth/domain/Auth.java
@@ -1,7 +1,10 @@
 package org.recordy.server.auth.domain;
 
+import lombok.Builder;
 import lombok.Getter;
+import org.recordy.server.user.domain.User;
 
+@Builder
 @Getter
 public class Auth {
 
@@ -9,4 +12,5 @@ public class Auth {
     private AuthPlatform platform;
     private AuthToken token;
     private AuthStatus status;
+    private User user;
 }

--- a/src/main/java/org/recordy/server/auth/domain/Auth.java
+++ b/src/main/java/org/recordy/server/auth/domain/Auth.java
@@ -9,4 +9,5 @@ public class Auth {
 
     private AuthPlatform platform;
     private AuthToken token;
+    private boolean isSignedUp;
 }

--- a/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
@@ -1,0 +1,14 @@
+package org.recordy.server.auth.domain;
+
+import org.recordy.server.common.domain.JpaMetaInfoEntity;
+
+public class AuthEntity extends JpaMetaInfoEntity {
+
+    public static AuthEntity from(Auth auth) {
+        return null;
+    }
+
+    public Auth toDomain() {
+        return null;
+    }
+}

--- a/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
@@ -1,18 +1,17 @@
 package org.recordy.server.auth.domain;
 
-import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.recordy.server.common.domain.JpaMetaInfoEntity;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @RedisHash("auth")
-public class AuthEntity extends JpaMetaInfoEntity {
+public class AuthEntity {
 
     @Id
     private String platformId;

--- a/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
@@ -1,14 +1,38 @@
 package org.recordy.server.auth.domain;
 
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.recordy.server.common.domain.JpaMetaInfoEntity;
+import org.springframework.data.redis.core.RedisHash;
 
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@RedisHash("auth")
 public class AuthEntity extends JpaMetaInfoEntity {
 
+    @Id
+    private String platformId;
+    private String platformType;
+    private String accessToken;
+    private String refreshToken;
+
     public static AuthEntity from(Auth auth) {
-        return null;
+        return new AuthEntity(
+                auth.getPlatform().getId(),
+                auth.getPlatform().getType().name(),
+                auth.getToken().getAccessToken(),
+                auth.getToken().getRefreshToken()
+        );
     }
 
     public Auth toDomain() {
-        return null;
+        return new Auth(
+                new AuthPlatform(platformId, AuthPlatform.Type.valueOf(platformType)),
+                new AuthToken(accessToken, refreshToken)
+        );
     }
 }

--- a/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
@@ -19,20 +19,23 @@ public class AuthEntity extends JpaMetaInfoEntity {
     private String platformType;
     private String accessToken;
     private String refreshToken;
+    private boolean isSignedUp;
 
     public static AuthEntity from(Auth auth) {
         return new AuthEntity(
                 auth.getPlatform().getId(),
                 auth.getPlatform().getType().name(),
                 auth.getToken().getAccessToken(),
-                auth.getToken().getRefreshToken()
+                auth.getToken().getRefreshToken(),
+                auth.isSignedUp()
         );
     }
 
     public Auth toDomain() {
         return new Auth(
                 new AuthPlatform(platformId, AuthPlatform.Type.valueOf(platformType)),
-                new AuthToken(accessToken, refreshToken)
+                new AuthToken(accessToken, refreshToken),
+                isSignedUp
         );
     }
 }

--- a/src/main/java/org/recordy/server/auth/domain/AuthPlatform.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthPlatform.java
@@ -1,0 +1,13 @@
+package org.recordy.server.auth.domain;
+
+public class AuthPlatform {
+
+    private String platformId;
+    private Type type;
+
+    public enum Type {
+        APPLE,
+        KAKAO,
+        ;
+    }
+}

--- a/src/main/java/org/recordy/server/auth/domain/AuthPlatform.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthPlatform.java
@@ -11,6 +11,7 @@ public class AuthPlatform {
     private Type type;
 
     public enum Type {
+
         APPLE,
         KAKAO,
         ;

--- a/src/main/java/org/recordy/server/auth/domain/AuthPlatform.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthPlatform.java
@@ -1,7 +1,9 @@
 package org.recordy.server.auth.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class AuthPlatform {
 

--- a/src/main/java/org/recordy/server/auth/domain/AuthPlatform.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthPlatform.java
@@ -1,8 +1,11 @@
 package org.recordy.server.auth.domain;
 
+import lombok.Getter;
+
+@Getter
 public class AuthPlatform {
 
-    private String platformId;
+    private String id;
     private Type type;
 
     public enum Type {

--- a/src/main/java/org/recordy/server/auth/domain/AuthStatus.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthStatus.java
@@ -1,8 +1,0 @@
-package org.recordy.server.auth.domain;
-
-public enum AuthStatus {
-    PENDING,
-    ACTIVE,
-    DELETED
-    ;
-}

--- a/src/main/java/org/recordy/server/auth/domain/AuthStatus.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthStatus.java
@@ -1,0 +1,8 @@
+package org.recordy.server.auth.domain;
+
+public enum AuthStatus {
+    PENDING,
+    ACTIVE,
+    DELETED
+    ;
+}

--- a/src/main/java/org/recordy/server/auth/domain/AuthToken.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthToken.java
@@ -1,7 +1,9 @@
 package org.recordy.server.auth.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class AuthToken {
 

--- a/src/main/java/org/recordy/server/auth/domain/AuthToken.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthToken.java
@@ -1,0 +1,10 @@
+package org.recordy.server.auth.domain;
+
+import lombok.Getter;
+
+@Getter
+public class AuthToken {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/org/recordy/server/auth/domain/usecase/AuthSignIn.java
+++ b/src/main/java/org/recordy/server/auth/domain/usecase/AuthSignIn.java
@@ -1,0 +1,13 @@
+package org.recordy.server.auth.domain.usecase;
+
+import org.recordy.server.auth.domain.AuthPlatform;
+
+public record AuthSignIn(
+        String platformToken,
+        AuthPlatform.Type platformType
+) {
+
+    public static AuthSignIn of(String platformToken, AuthPlatform.Type platformType) {
+        return new AuthSignIn(platformToken, platformType);
+    }
+}

--- a/src/main/java/org/recordy/server/auth/repository/AuthRepository.java
+++ b/src/main/java/org/recordy/server/auth/repository/AuthRepository.java
@@ -1,0 +1,8 @@
+package org.recordy.server.auth.repository;
+
+import org.recordy.server.auth.domain.Auth;
+
+public interface AuthRepository {
+
+    Auth save(Auth auth);
+}

--- a/src/main/java/org/recordy/server/auth/repository/impl/AuthRedisRepository.java
+++ b/src/main/java/org/recordy/server/auth/repository/impl/AuthRedisRepository.java
@@ -1,0 +1,7 @@
+package org.recordy.server.auth.repository.impl;
+
+import org.recordy.server.auth.domain.AuthEntity;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AuthRedisRepository extends CrudRepository<AuthEntity, String> {
+}

--- a/src/main/java/org/recordy/server/auth/repository/impl/AuthRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/auth/repository/impl/AuthRepositoryImpl.java
@@ -1,0 +1,20 @@
+package org.recordy.server.auth.repository.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.AuthEntity;
+import org.recordy.server.auth.repository.AuthRepository;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class AuthRepositoryImpl implements AuthRepository {
+
+    private final AuthRedisRepository authRedisRepository;
+
+    @Override
+    public Auth save(Auth auth) {
+        return authRedisRepository.save(AuthEntity.from(auth))
+                .toDomain();
+    }
+}

--- a/src/main/java/org/recordy/server/auth/service/AuthPlatformService.java
+++ b/src/main/java/org/recordy/server/auth/service/AuthPlatformService.java
@@ -1,0 +1,9 @@
+package org.recordy.server.auth.service;
+
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.domain.AuthPlatform;
+
+public interface AuthPlatformService {
+
+    AuthPlatform getPlatform(AuthSignIn authSignIn);
+}

--- a/src/main/java/org/recordy/server/auth/service/AuthPlatformService.java
+++ b/src/main/java/org/recordy/server/auth/service/AuthPlatformService.java
@@ -6,4 +6,5 @@ import org.recordy.server.auth.domain.AuthPlatform;
 public interface AuthPlatformService {
 
     AuthPlatform getPlatform(AuthSignIn authSignIn);
+    AuthPlatform.Type getPlatformType();
 }

--- a/src/main/java/org/recordy/server/auth/service/AuthPlatformServiceFactory.java
+++ b/src/main/java/org/recordy/server/auth/service/AuthPlatformServiceFactory.java
@@ -1,0 +1,25 @@
+package org.recordy.server.auth.service;
+
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class AuthPlatformServiceFactory {
+
+    private final Map<AuthPlatform.Type, AuthPlatformService> platformServices;
+
+    public AuthPlatformServiceFactory(List<AuthPlatformService> platformServices) {
+        this.platformServices = new HashMap<>();
+
+        platformServices.forEach(
+                platformService -> this.platformServices.put(platformService.getPlatformType(), platformService));
+    }
+
+    public AuthPlatformService getPlatformServiceFrom(AuthPlatform.Type platformType) {
+        return platformServices.get(platformType);
+    }
+}

--- a/src/main/java/org/recordy/server/auth/service/AuthService.java
+++ b/src/main/java/org/recordy/server/auth/service/AuthService.java
@@ -1,0 +1,9 @@
+package org.recordy.server.auth.service;
+
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+
+public interface AuthService {
+
+    Auth signIn(AuthSignIn authSignIn);
+}

--- a/src/main/java/org/recordy/server/auth/service/AuthTokenService.java
+++ b/src/main/java/org/recordy/server/auth/service/AuthTokenService.java
@@ -1,8 +1,10 @@
 package org.recordy.server.auth.service;
 
 import org.recordy.server.auth.domain.AuthToken;
+import org.recordy.server.auth.service.dto.AuthTokenValidationResult;
 
 public interface AuthTokenService {
 
     AuthToken issueToken(long userId);
+    AuthTokenValidationResult validateToken(String token);
 }

--- a/src/main/java/org/recordy/server/auth/service/AuthTokenService.java
+++ b/src/main/java/org/recordy/server/auth/service/AuthTokenService.java
@@ -1,0 +1,8 @@
+package org.recordy.server.auth.service;
+
+import org.recordy.server.auth.domain.AuthToken;
+
+public interface AuthTokenService {
+
+    AuthToken issueToken(long userId);
+}

--- a/src/main/java/org/recordy/server/auth/service/dto/AuthTokenValidationResult.java
+++ b/src/main/java/org/recordy/server/auth/service/dto/AuthTokenValidationResult.java
@@ -1,0 +1,10 @@
+package org.recordy.server.auth.service.dto;
+
+public enum AuthTokenValidationResult {
+    VALID_JWT,              // 유효한 토큰
+    INVALID_SIGNATURE,      // 유효하지 않은 서명
+    INVALID_TOKEN,          // 유효하지 않은 토큰
+    EXPIRED_TOKEN,          // 만료된 토큰
+    UNSUPPORTED_TOKEN,      // 지원하지 않는 형식의 토큰
+    EMPTY_TOKEN             // 빈 토큰
+}

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthPlatformServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthPlatformServiceImpl.java
@@ -1,0 +1,17 @@
+package org.recordy.server.auth.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.service.AuthPlatformService;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthPlatformServiceImpl implements AuthPlatformService {
+
+    @Override
+    public AuthPlatform getPlatform(AuthSignIn authSignIn) {
+        return null;
+    }
+}

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
@@ -14,6 +14,8 @@ import org.recordy.server.user.domain.UserStatus;
 import org.recordy.server.user.service.UserService;
 import org.springframework.stereotype.Service;
 
+import static org.recordy.server.user.domain.UserStatus.ACTIVE;
+
 @RequiredArgsConstructor
 @Service
 public class AuthServiceImpl implements AuthService {
@@ -29,7 +31,7 @@ public class AuthServiceImpl implements AuthService {
         User user = getOrCreateUser(platform);
         AuthToken token = authTokenService.issueToken(user.getId());
 
-        return create(platform, token);
+        return create(platform, token, user.getStatus());
     }
 
     private User getOrCreateUser(AuthPlatform platform) {
@@ -37,10 +39,11 @@ public class AuthServiceImpl implements AuthService {
                 .orElseGet(() -> userService.create(platform, UserStatus.PENDING));
     }
 
-    private Auth create(AuthPlatform platform, AuthToken token) {
+    private Auth create(AuthPlatform platform, AuthToken token, UserStatus userStatus) {
         return authRepository.save(Auth.builder()
                 .platform(platform)
                 .token(token)
+                .isSignedUp(userStatus.equals(ACTIVE))
                 .build());
     }
 }

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
@@ -7,6 +7,7 @@ import org.recordy.server.auth.domain.AuthToken;
 import org.recordy.server.auth.domain.usecase.AuthSignIn;
 import org.recordy.server.auth.repository.AuthRepository;
 import org.recordy.server.auth.service.AuthPlatformService;
+import org.recordy.server.auth.service.AuthPlatformServiceFactory;
 import org.recordy.server.auth.service.AuthService;
 import org.recordy.server.auth.service.AuthTokenService;
 import org.recordy.server.user.domain.User;
@@ -21,17 +22,23 @@ import static org.recordy.server.user.domain.UserStatus.ACTIVE;
 public class AuthServiceImpl implements AuthService {
 
     private final AuthRepository authRepository;
-    private final AuthPlatformService platformService;
+    private final AuthPlatformServiceFactory platformServiceFactory;
     private final AuthTokenService authTokenService;
     private final UserService userService;
 
     @Override
     public Auth signIn(AuthSignIn authSignIn) {
-        AuthPlatform platform = platformService.getPlatform(authSignIn);
+        AuthPlatform platform = getPlatform(authSignIn);
         User user = getOrCreateUser(platform);
         AuthToken token = authTokenService.issueToken(user.getId());
 
         return create(platform, token, user.getStatus());
+    }
+
+    private AuthPlatform getPlatform(AuthSignIn authSignIn) {
+        AuthPlatformService platformService = platformServiceFactory.getPlatformServiceFrom(authSignIn.platformType());
+
+        return platformService.getPlatform(authSignIn);
     }
 
     private User getOrCreateUser(AuthPlatform platform) {

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
@@ -1,0 +1,48 @@
+package org.recordy.server.auth.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.AuthStatus;
+import org.recordy.server.auth.domain.AuthToken;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.repository.AuthRepository;
+import org.recordy.server.auth.service.AuthPlatformService;
+import org.recordy.server.auth.service.AuthService;
+import org.recordy.server.auth.service.AuthTokenService;
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.service.UserService;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthServiceImpl implements AuthService {
+
+    private final AuthRepository authRepository;
+    private final AuthPlatformService platformService;
+    private final AuthTokenService authTokenService;
+    private final UserService userService;
+
+    @Override
+    public Auth signIn(AuthSignIn authSignIn) {
+        AuthPlatform platform = platformService.getPlatform(authSignIn);
+        User user = getOrCreateUser(platform);
+        AuthToken token = authTokenService.issueToken(user.getId());
+
+        return create(platform, token, user);
+    }
+
+    private User getOrCreateUser(AuthPlatform platform) {
+        return userService.getByPlatformId(platform.getId())
+                .orElseGet(() -> userService.create(platform));
+    }
+
+    private Auth create(AuthPlatform platform, AuthToken token, User user) {
+        return Auth.builder()
+                .platform(platform)
+                .token(token)
+                .status(AuthStatus.PENDING)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
@@ -3,7 +3,6 @@ package org.recordy.server.auth.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.recordy.server.auth.domain.Auth;
 import org.recordy.server.auth.domain.AuthPlatform;
-import org.recordy.server.auth.domain.AuthStatus;
 import org.recordy.server.auth.domain.AuthToken;
 import org.recordy.server.auth.domain.usecase.AuthSignIn;
 import org.recordy.server.auth.repository.AuthRepository;
@@ -11,6 +10,7 @@ import org.recordy.server.auth.service.AuthPlatformService;
 import org.recordy.server.auth.service.AuthService;
 import org.recordy.server.auth.service.AuthTokenService;
 import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserStatus;
 import org.recordy.server.user.service.UserService;
 import org.springframework.stereotype.Service;
 
@@ -34,15 +34,14 @@ public class AuthServiceImpl implements AuthService {
 
     private User getOrCreateUser(AuthPlatform platform) {
         return userService.getByPlatformId(platform.getId())
-                .orElseGet(() -> userService.create(platform));
+                .orElseGet(() -> userService.create(platform, UserStatus.PENDING));
     }
 
     private Auth create(AuthPlatform platform, AuthToken token, User user) {
-        return Auth.builder()
+        return authRepository.save(Auth.builder()
                 .platform(platform)
                 .token(token)
-                .status(AuthStatus.PENDING)
                 .user(user)
-                .build();
+                .build());
     }
 }

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
@@ -36,7 +36,7 @@ public class AuthServiceImpl implements AuthService {
 
     private User getOrCreateUser(AuthPlatform platform) {
         return userService.getByPlatformId(platform.getId())
-                .orElseGet(() -> userService.create(platform, UserStatus.PENDING));
+                .orElseGet(() -> userService.create(platform));
     }
 
     private Auth create(AuthPlatform platform, AuthToken token, UserStatus userStatus) {

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
@@ -29,7 +29,7 @@ public class AuthServiceImpl implements AuthService {
         User user = getOrCreateUser(platform);
         AuthToken token = authTokenService.issueToken(user.getId());
 
-        return create(platform, token, user);
+        return create(platform, token);
     }
 
     private User getOrCreateUser(AuthPlatform platform) {
@@ -37,11 +37,10 @@ public class AuthServiceImpl implements AuthService {
                 .orElseGet(() -> userService.create(platform, UserStatus.PENDING));
     }
 
-    private Auth create(AuthPlatform platform, AuthToken token, User user) {
+    private Auth create(AuthPlatform platform, AuthToken token) {
         return authRepository.save(Auth.builder()
                 .platform(platform)
                 .token(token)
-                .user(user)
                 .build());
     }
 }

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthTokenServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthTokenServiceImpl.java
@@ -1,0 +1,16 @@
+package org.recordy.server.auth.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.auth.domain.AuthToken;
+import org.recordy.server.auth.service.AuthTokenService;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthTokenServiceImpl implements AuthTokenService {
+
+    @Override
+    public AuthToken issueToken(long userId) {
+        return null;
+    }
+}

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthTokenServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthTokenServiceImpl.java
@@ -3,6 +3,7 @@ package org.recordy.server.auth.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.recordy.server.auth.domain.AuthToken;
 import org.recordy.server.auth.service.AuthTokenService;
+import org.recordy.server.auth.service.dto.AuthTokenValidationResult;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -11,6 +12,11 @@ public class AuthTokenServiceImpl implements AuthTokenService {
 
     @Override
     public AuthToken issueToken(long userId) {
+        return null;
+    }
+
+    @Override
+    public AuthTokenValidationResult validateToken(String token) {
         return null;
     }
 }

--- a/src/main/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImpl.java
@@ -1,4 +1,4 @@
-package org.recordy.server.auth.service.impl;
+package org.recordy.server.auth.service.impl.apple;
 
 import lombok.RequiredArgsConstructor;
 import org.recordy.server.auth.domain.AuthPlatform;
@@ -8,10 +8,15 @@ import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class AuthPlatformServiceImpl implements AuthPlatformService {
+public class AuthApplePlatformServiceImpl implements AuthPlatformService {
 
     @Override
     public AuthPlatform getPlatform(AuthSignIn authSignIn) {
         return null;
+    }
+
+    @Override
+    public AuthPlatform.Type getPlatformType() {
+        return AuthPlatform.Type.APPLE;
     }
 }

--- a/src/main/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImpl.java
@@ -1,0 +1,22 @@
+package org.recordy.server.auth.service.impl.kakao;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.service.AuthPlatformService;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthKakaoPlatformServiceImpl implements AuthPlatformService {
+
+    @Override
+    public AuthPlatform getPlatform(AuthSignIn authSignIn) {
+        return null;
+    }
+
+    @Override
+    public AuthPlatform.Type getPlatformType() {
+        return AuthPlatform.Type.KAKAO;
+    }
+}

--- a/src/main/java/org/recordy/server/common/config/FeignClientConfig.java
+++ b/src/main/java/org/recordy/server/common/config/FeignClientConfig.java
@@ -1,0 +1,9 @@
+package org.recordy.server.common.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients(basePackages = "org.recordy.server.auth.service.impl")
+@Configuration
+public class FeignClientConfig {
+}

--- a/src/main/java/org/recordy/server/common/config/JpaEntityAuditingConfig.java
+++ b/src/main/java/org/recordy/server/common/config/JpaEntityAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.recordy.server.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaEntityAuditingConfig {
+}

--- a/src/main/java/org/recordy/server/common/domain/JpaMetaInfoEntity.java
+++ b/src/main/java/org/recordy/server/common/domain/JpaMetaInfoEntity.java
@@ -3,9 +3,7 @@ package org.recordy.server.common.domain;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -19,12 +17,6 @@ public abstract class JpaMetaInfoEntity {
     @CreatedDate
     protected LocalDateTime createdAt;
 
-    @CreatedBy
-    protected long createdBy;
-
     @LastModifiedDate
     protected LocalDateTime updatedAt;
-
-    @LastModifiedBy
-    protected long updatedBy;
 }

--- a/src/main/java/org/recordy/server/common/domain/JpaMetaInfoEntity.java
+++ b/src/main/java/org/recordy/server/common/domain/JpaMetaInfoEntity.java
@@ -1,0 +1,30 @@
+package org.recordy.server.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public abstract class JpaMetaInfoEntity {
+
+    @CreatedDate
+    protected LocalDateTime createdAt;
+
+    @CreatedBy
+    protected long createdBy;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    protected long updatedBy;
+}

--- a/src/main/java/org/recordy/server/user/controller/UserApi.java
+++ b/src/main/java/org/recordy/server/user/controller/UserApi.java
@@ -1,0 +1,4 @@
+package org.recordy.server.user.controller;
+
+public interface UserApi {
+}

--- a/src/main/java/org/recordy/server/user/controller/UserController.java
+++ b/src/main/java/org/recordy/server/user/controller/UserController.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("${api.base-path}" + "/user")
+@RequestMapping("/api/v1/users")
 @RestController
 public class UserController {
 

--- a/src/main/java/org/recordy/server/user/controller/UserController.java
+++ b/src/main/java/org/recordy/server/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package org.recordy.server.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.service.AuthService;
+import org.recordy.server.user.controller.dto.request.UserSignInRequest;
+import org.recordy.server.user.controller.dto.response.UserSignInResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/")
+@RestController("${api.base-path}" + "/user")
+public class UserController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signIn")
+    public ResponseEntity<UserSignInResponse> signIn(
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String platformToken,
+        @RequestBody UserSignInRequest request
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(UserSignInResponse.from(
+                        authService.signIn(AuthSignIn.of(platformToken, request.platformType()))
+                ));
+    }
+}

--- a/src/main/java/org/recordy/server/user/controller/UserController.java
+++ b/src/main/java/org/recordy/server/user/controller/UserController.java
@@ -11,8 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/")
-@RestController("${api.base-path}" + "/user")
+@RequestMapping("${api.base-path}" + "/user")
+@RestController
 public class UserController {
 
     private final AuthService authService;

--- a/src/main/java/org/recordy/server/user/controller/dto/request/UserSignInRequest.java
+++ b/src/main/java/org/recordy/server/user/controller/dto/request/UserSignInRequest.java
@@ -1,0 +1,8 @@
+package org.recordy.server.user.controller.dto.request;
+
+import org.recordy.server.auth.domain.AuthPlatform;
+
+public record UserSignInRequest(
+        AuthPlatform.Type platformType
+) {
+}

--- a/src/main/java/org/recordy/server/user/controller/dto/response/UserSignInResponse.java
+++ b/src/main/java/org/recordy/server/user/controller/dto/response/UserSignInResponse.java
@@ -5,14 +5,14 @@ import org.recordy.server.auth.domain.Auth;
 public record UserSignInResponse(
         String accessToken,
         String refreshToken,
-        String userStatus
+        boolean isSignedUp
 ) {
 
     public static UserSignInResponse from(Auth auth) {
         return new UserSignInResponse(
                 auth.getToken().getAccessToken(),
                 auth.getToken().getRefreshToken(),
-                auth.getStatus().name()
+                auth.isSignedUp()
         );
     }
 }

--- a/src/main/java/org/recordy/server/user/controller/dto/response/UserSignInResponse.java
+++ b/src/main/java/org/recordy/server/user/controller/dto/response/UserSignInResponse.java
@@ -1,0 +1,18 @@
+package org.recordy.server.user.controller.dto.response;
+
+import org.recordy.server.auth.domain.Auth;
+
+public record UserSignInResponse(
+        String accessToken,
+        String refreshToken,
+        String userStatus
+) {
+
+    public static UserSignInResponse from(Auth auth) {
+        return new UserSignInResponse(
+                auth.getToken().getAccessToken(),
+                auth.getToken().getRefreshToken(),
+                auth.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/org/recordy/server/user/domain/User.java
+++ b/src/main/java/org/recordy/server/user/domain/User.java
@@ -1,11 +1,12 @@
 package org.recordy.server.user.domain;
 
 import lombok.Getter;
-import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.AuthPlatform;
 
 @Getter
 public class User {
 
     private Long id;
-    private Auth auth;
+    private AuthPlatform authPlatform;
+    private UserStatus status;
 }

--- a/src/main/java/org/recordy/server/user/domain/User.java
+++ b/src/main/java/org/recordy/server/user/domain/User.java
@@ -1,10 +1,12 @@
 package org.recordy.server.user.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.recordy.server.auth.domain.AuthPlatform;
 
 @AllArgsConstructor
+@Builder
 @Getter
 public class User {
 

--- a/src/main/java/org/recordy/server/user/domain/User.java
+++ b/src/main/java/org/recordy/server/user/domain/User.java
@@ -1,8 +1,10 @@
 package org.recordy.server.user.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.recordy.server.auth.domain.AuthPlatform;
 
+@AllArgsConstructor
 @Getter
 public class User {
 

--- a/src/main/java/org/recordy/server/user/domain/User.java
+++ b/src/main/java/org/recordy/server/user/domain/User.java
@@ -1,0 +1,5 @@
+package org.recordy.server.user.domain;
+
+public class User {
+
+}

--- a/src/main/java/org/recordy/server/user/domain/User.java
+++ b/src/main/java/org/recordy/server/user/domain/User.java
@@ -1,5 +1,11 @@
 package org.recordy.server.user.domain;
 
+import lombok.Getter;
+import org.recordy.server.auth.domain.Auth;
+
+@Getter
 public class User {
 
+    private Long id;
+    private Auth auth;
 }

--- a/src/main/java/org/recordy/server/user/domain/UserEntity.java
+++ b/src/main/java/org/recordy/server/user/domain/UserEntity.java
@@ -16,11 +16,13 @@ public class UserEntity extends JpaMetaInfoEntity {
     private Long id;
 
     private String platformId;
+    @Enumerated(EnumType.STRING)
     private AuthPlatform.Type platformType;
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
-    public UserEntity(String platformId, AuthPlatform.Type platformType, UserStatus status) {
+    public UserEntity(Long id, String platformId, AuthPlatform.Type platformType, UserStatus status) {
+        this.id = id;
         this.platformId = platformId;
         this.platformType = platformType;
         this.status = status;
@@ -28,6 +30,7 @@ public class UserEntity extends JpaMetaInfoEntity {
 
     public static UserEntity from(User user) {
         return new UserEntity(
+                user.getId(),
                 user.getAuthPlatform().getId(),
                 user.getAuthPlatform().getType(),
                 user.getStatus()

--- a/src/main/java/org/recordy/server/user/domain/UserEntity.java
+++ b/src/main/java/org/recordy/server/user/domain/UserEntity.java
@@ -1,0 +1,14 @@
+package org.recordy.server.user.domain;
+
+import org.recordy.server.common.domain.JpaMetaInfoEntity;
+
+public class UserEntity extends JpaMetaInfoEntity {
+
+    public static UserEntity from(User user) {
+        return null;
+    }
+
+    public User toDomain() {
+        return null;
+    }
+}

--- a/src/main/java/org/recordy/server/user/domain/UserEntity.java
+++ b/src/main/java/org/recordy/server/user/domain/UserEntity.java
@@ -1,14 +1,44 @@
 package org.recordy.server.user.domain;
 
+import jakarta.persistence.*;
+import lombok.*;
+import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.common.domain.JpaMetaInfoEntity;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "users")
+@Entity
 public class UserEntity extends JpaMetaInfoEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String platformId;
+    private AuthPlatform.Type platformType;
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+
+    public UserEntity(String platformId, AuthPlatform.Type platformType, UserStatus status) {
+        this.platformId = platformId;
+        this.platformType = platformType;
+        this.status = status;
+    }
+
     public static UserEntity from(User user) {
-        return null;
+        return new UserEntity(
+                user.getAuthPlatform().getId(),
+                user.getAuthPlatform().getType(),
+                user.getStatus()
+        );
     }
 
     public User toDomain() {
-        return null;
+        return new User(
+                id,
+                new AuthPlatform(platformId, platformType),
+                status
+        );
     }
 }

--- a/src/main/java/org/recordy/server/user/domain/UserStatus.java
+++ b/src/main/java/org/recordy/server/user/domain/UserStatus.java
@@ -1,0 +1,9 @@
+package org.recordy.server.user.domain;
+
+public enum UserStatus {
+
+    PENDING,
+    ACTIVE,
+    DELETED
+    ;
+}

--- a/src/main/java/org/recordy/server/user/repository/UserRepository.java
+++ b/src/main/java/org/recordy/server/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package org.recordy.server.user.repository;
+
+import org.recordy.server.user.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    // command
+    User save(User user);
+
+    // query
+    Optional<User> findByPlatformId(String platformId);
+}

--- a/src/main/java/org/recordy/server/user/repository/impl/UserJpaRepository.java
+++ b/src/main/java/org/recordy/server/user/repository/impl/UserJpaRepository.java
@@ -1,0 +1,11 @@
+package org.recordy.server.user.repository.impl;
+
+import org.recordy.server.user.domain.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+
+    Optional<UserEntity> findByPlatformId(String platformId);
+}

--- a/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
@@ -1,0 +1,28 @@
+package org.recordy.server.user.repository.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserEntity;
+import org.recordy.server.user.repository.UserRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public User save(User user) {
+        return userJpaRepository.save(UserEntity.from(user))
+                .toDomain();
+    }
+
+    @Override
+    public Optional<User> findByPlatformId(String platformId) {
+        return userJpaRepository.findByPlatformId(platformId)
+                .map(UserEntity::toDomain);
+    }
+}

--- a/src/main/java/org/recordy/server/user/service/UserService.java
+++ b/src/main/java/org/recordy/server/user/service/UserService.java
@@ -2,13 +2,14 @@ package org.recordy.server.user.service;
 
 import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserStatus;
 
 import java.util.Optional;
 
 public interface UserService {
 
     // command
-    User create(AuthPlatform platform);
+    User create(AuthPlatform platform, UserStatus userStatus);
 
     // query
     Optional<User> getByPlatformId(String platformId);

--- a/src/main/java/org/recordy/server/user/service/UserService.java
+++ b/src/main/java/org/recordy/server/user/service/UserService.java
@@ -2,14 +2,13 @@ package org.recordy.server.user.service;
 
 import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.user.domain.User;
-import org.recordy.server.user.domain.UserStatus;
 
 import java.util.Optional;
 
 public interface UserService {
 
     // command
-    User create(AuthPlatform platform, UserStatus userStatus);
+    User create(AuthPlatform platform);
 
     // query
     Optional<User> getByPlatformId(String platformId);

--- a/src/main/java/org/recordy/server/user/service/UserService.java
+++ b/src/main/java/org/recordy/server/user/service/UserService.java
@@ -1,0 +1,14 @@
+package org.recordy.server.user.service;
+
+import org.recordy.server.user.domain.User;
+
+import java.util.Optional;
+
+public interface UserService {
+
+    // command
+    User create(User user);
+
+    // query
+    Optional<User> getByPlatformId(String platformId);
+}

--- a/src/main/java/org/recordy/server/user/service/UserService.java
+++ b/src/main/java/org/recordy/server/user/service/UserService.java
@@ -1,5 +1,6 @@
 package org.recordy.server.user.service;
 
+import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.user.domain.User;
 
 import java.util.Optional;
@@ -7,7 +8,7 @@ import java.util.Optional;
 public interface UserService {
 
     // command
-    User create(User user);
+    User create(AuthPlatform platform);
 
     // query
     Optional<User> getByPlatformId(String platformId);

--- a/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,25 @@
+package org.recordy.server.user.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserStatus;
+import org.recordy.server.user.service.UserService;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class UserServiceImpl implements UserService {
+
+    @Override
+    public User create(AuthPlatform platform, UserStatus userStatus) {
+        return null;
+    }
+
+    @Override
+    public Optional<User> getByPlatformId(String platformId) {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.UserStatus;
+import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.user.service.UserService;
 import org.springframework.stereotype.Service;
 
@@ -13,13 +14,18 @@ import java.util.Optional;
 @Service
 public class UserServiceImpl implements UserService {
 
+    private final UserRepository userRepository;
+
     @Override
-    public User create(AuthPlatform platform, UserStatus userStatus) {
-        return null;
+    public User create(AuthPlatform platform) {
+        return userRepository.save(User.builder()
+                .authPlatform(platform)
+                .status(UserStatus.PENDING)
+                .build());
     }
 
     @Override
     public Optional<User> getByPlatformId(String platformId) {
-        return Optional.empty();
+        return userRepository.findByPlatformId(platformId);
     }
 }

--- a/src/test/java/org/recordy/server/auth/domain/AuthEntityTest.java
+++ b/src/test/java/org/recordy/server/auth/domain/AuthEntityTest.java
@@ -1,0 +1,50 @@
+package org.recordy.server.auth.domain;
+
+import org.junit.jupiter.api.Test;
+import org.recordy.server.util.DomainFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class AuthEntityTest {
+
+    @Test
+    void from을_통해_Auth_객체로부터_AuthEntity_객체를_생성할_수_있다() {
+        // given
+        Auth auth = Auth.builder()
+                .platform(DomainFixture.createAuthPlatform())
+                .token(DomainFixture.createAuthToken())
+                .isSignedUp(true)
+                .build();
+
+        // when
+        AuthEntity authEntity = AuthEntity.from(auth);
+
+        // then
+        assertAll(
+                () -> assertThat(authEntity.getPlatformId()).isEqualTo(auth.getPlatform().getId()),
+                () -> assertThat(authEntity.getPlatformType()).isEqualTo(auth.getPlatform().getType().name()),
+                () -> assertThat(authEntity.getAccessToken()).isEqualTo(auth.getToken().getAccessToken()),
+                () -> assertThat(authEntity.getRefreshToken()).isEqualTo(auth.getToken().getRefreshToken()),
+                () -> assertThat(authEntity.isSignedUp()).isEqualTo(auth.isSignedUp())
+        );
+    }
+
+    @Test
+    void toDomain을_통해_AuthEntity_객체로부터_Auth_객체를_생성할_수_있다() {
+        // given
+        AuthEntity authEntity = DomainFixture.createAuthEntity(true);
+
+        // when
+        Auth auth = authEntity.toDomain();
+
+        // then
+        assertAll(
+                () -> assertThat(auth.getPlatform().getId()).isEqualTo(authEntity.getPlatformId()),
+                () -> assertThat(auth.getPlatform().getType().name()).isEqualTo(authEntity.getPlatformType()),
+                () -> assertThat(auth.getToken().getAccessToken()).isEqualTo(authEntity.getAccessToken()),
+                () -> assertThat(auth.getToken().getRefreshToken()).isEqualTo(authEntity.getRefreshToken()),
+                () -> assertThat(auth.isSignedUp()).isEqualTo(authEntity.isSignedUp())
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/auth/domain/usecase/AuthSignInTest.java
+++ b/src/test/java/org/recordy/server/auth/domain/usecase/AuthSignInTest.java
@@ -1,0 +1,27 @@
+package org.recordy.server.auth.domain.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.util.DomainFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class AuthSignInTest {
+
+    @Test
+    void of를_통해_AuthSignIn_객체를_생성할_수_있다() {
+        // given
+        String platformToken = DomainFixture.PLATFORM_TOKEN;
+        AuthPlatform.Type platformType = AuthPlatform.Type.KAKAO;
+
+        // when
+        AuthSignIn authSignIn = AuthSignIn.of(platformToken, platformType);
+
+        // then
+        assertAll(
+                () -> assertThat(authSignIn.platformToken()).isEqualTo(platformToken),
+                () -> assertThat(authSignIn.platformType()).isEqualTo(platformType)
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/auth/repository/AuthRepositoryIntegrationTest.java
+++ b/src/test/java/org/recordy/server/auth/repository/AuthRepositoryIntegrationTest.java
@@ -17,11 +17,6 @@ public class AuthRepositoryIntegrationTest {
     @Autowired
     private AuthRepository authRepository;
 
-    @BeforeEach
-    void setUp() {
-        authRepository.save(DomainFixture.createAuth(true));
-    }
-
     @Test
     void save를_통해_인증_데이터를_저장할_수_있다() {
         // given

--- a/src/test/java/org/recordy/server/auth/repository/AuthRepositoryIntegrationTest.java
+++ b/src/test/java/org/recordy/server/auth/repository/AuthRepositoryIntegrationTest.java
@@ -1,0 +1,49 @@
+package org.recordy.server.auth.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.util.DomainFixture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+public class AuthRepositoryIntegrationTest {
+
+    @Autowired
+    private AuthRepository authRepository;
+
+    @BeforeEach
+    void setUp() {
+        authRepository.save(DomainFixture.createAuth(true));
+    }
+
+    @Test
+    void save를_통해_인증_데이터를_저장할_수_있다() {
+        // given
+        String id = "abc";
+        boolean isSignedUp = true;
+
+        Auth auth = new Auth(
+                new AuthPlatform(id, AuthPlatform.Type.KAKAO),
+                DomainFixture.createAuthToken(),
+                isSignedUp
+        );
+
+        // when
+        Auth result = authRepository.save(auth);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getPlatform().getId()).isEqualTo(id),
+                () -> assertThat(result.getPlatform().getType()).isEqualTo(AuthPlatform.Type.KAKAO),
+                () -> assertThat(result.getToken().getAccessToken()).isEqualTo(DomainFixture.ACCESS_TOKEN),
+                () -> assertThat(result.getToken().getRefreshToken()).isEqualTo(DomainFixture.REFRESH_TOKEN),
+                () -> assertThat(result.isSignedUp()).isEqualTo(isSignedUp)
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
@@ -56,8 +56,7 @@ class AuthServiceIntegrationTest {
                 .thenReturn(DomainFixture.createAuthToken());
     }
 
-    //TODO: 클라이언트 측에서 애플 로그인 구현한 이후에 테스트 가능
-//    @Test
+    @Test
     void signIn을_요청한_가입되지_않은_사용자에_대해_새로운_User_객체가_저장된다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
@@ -76,7 +75,7 @@ class AuthServiceIntegrationTest {
         );
     }
 
-//    @Test
+    @Test
     void signIn을_요청한_가입되지_않은_사용자는_isSignedUp이_false인_Auth_객체를_반환한다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
@@ -91,7 +90,7 @@ class AuthServiceIntegrationTest {
         );
     }
 
-//    @Test
+    @Test
     void signIn을_요청한_가입되지_않은_사용자는_PENDING_상태로_가입_처리된다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
@@ -110,7 +109,7 @@ class AuthServiceIntegrationTest {
         );
     }
 
-//    @Test
+    @Test
     void signIn을_요청한_이미_가입된_사용자는_isSignedUp이_true인_Auth_객체를_반환한다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
@@ -127,7 +126,7 @@ class AuthServiceIntegrationTest {
         );
     }
 
-//    @Test
+    @Test
     void signIn을_요청한_이미_가입된_사용자는_ACTIVE_상태다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;

--- a/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
@@ -35,7 +35,8 @@ class AuthServiceIntegrationTest {
         authRepository.save(DomainFixture.createAuth(true));
     }
 
-    @Test
+    //TODO: 클라이언트 측에서 애플 로그인 구현한 이후에 테스트 가능
+//    @Test
     void signIn을_요청한_가입되지_않은_사용자에_대해_새로운_User_객체가_저장된다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
@@ -53,7 +54,7 @@ class AuthServiceIntegrationTest {
         );
     }
 
-    @Test
+//    @Test
     void signIn을_요청한_가입되지_않은_사용자는_isSignedUp이_false인_Auth_객체를_반환한다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
@@ -68,7 +69,7 @@ class AuthServiceIntegrationTest {
         );
     }
 
-    @Test
+//    @Test
     void signIn을_요청한_가입되지_않은_사용자는_PENDING_상태로_가입_처리된다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
@@ -87,7 +88,7 @@ class AuthServiceIntegrationTest {
         );
     }
 
-    @Test
+//    @Test
     void signIn을_요청한_이미_가입된_사용자는_isSignedUp이_true인_Auth_객체를_반환한다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
@@ -104,7 +105,7 @@ class AuthServiceIntegrationTest {
         );
     }
 
-    @Test
+//    @Test
     void signIn을_요청한_이미_가입된_사용자는_ACTIVE_상태다() {
         // given
         AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;

--- a/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
@@ -6,7 +6,6 @@ import org.mockito.Mockito;
 import org.recordy.server.auth.domain.Auth;
 import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.auth.domain.usecase.AuthSignIn;
-import org.recordy.server.auth.repository.AuthRepository;
 import org.recordy.server.mock.FakeContainer;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.UserStatus;
@@ -54,7 +53,7 @@ class AuthServiceIntegrationTest {
     @Test
     void signIn을_요청한_가입되지_않은_사용자에_대해_새로운_User_객체가_저장된다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
 
@@ -73,7 +72,7 @@ class AuthServiceIntegrationTest {
     @Test
     void signIn을_요청한_가입되지_않은_사용자는_isSignedUp이_false인_Auth_객체를_반환한다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         // when
@@ -88,7 +87,7 @@ class AuthServiceIntegrationTest {
     @Test
     void signIn을_요청한_가입되지_않은_사용자는_PENDING_상태로_가입_처리된다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         // when
@@ -107,7 +106,7 @@ class AuthServiceIntegrationTest {
     @Test
     void signIn을_요청한_이미_가입된_사용자는_isSignedUp이_true인_Auth_객체를_반환한다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         userRepository.save(DomainFixture.createUser());
@@ -124,7 +123,7 @@ class AuthServiceIntegrationTest {
     @Test
     void signIn을_요청한_이미_가입된_사용자는_ACTIVE_상태다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         userRepository.save(DomainFixture.createUser());

--- a/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
@@ -1,0 +1,125 @@
+package org.recordy.server.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.repository.AuthRepository;
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserStatus;
+import org.recordy.server.user.repository.UserRepository;
+import org.recordy.server.util.DomainFixture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+class AuthServiceIntegrationTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private AuthRepository authRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void init() {
+        authRepository.save(DomainFixture.createAuth(true));
+    }
+
+    @Test
+    void signIn을_요청한_가입되지_않은_사용자에_대해_새로운_User_객체가_저장된다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+        Optional<User> user = userRepository.findByPlatformId(auth.getPlatform().getId());
+
+        // then
+        assertAll(
+                () -> assertThat(user).isNotEmpty(),
+                () -> assertThat(user.get().getAuthPlatform().getId()).isEqualTo(auth.getPlatform().getId()),
+                () -> assertThat(user.get().getAuthPlatform().getType()).isEqualTo(auth.getPlatform().getType())
+        );
+    }
+
+    @Test
+    void signIn을_요청한_가입되지_않은_사용자는_isSignedUp이_false인_Auth_객체를_반환한다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+
+        // then
+        assertAll(
+                () -> assertThat(auth.isSignedUp()).isFalse()
+        );
+    }
+
+    @Test
+    void signIn을_요청한_가입되지_않은_사용자는_PENDING_상태로_가입_처리된다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+        Optional<User> user = userRepository.findByPlatformId(auth.getPlatform().getId());
+
+        // then
+        assertAll(
+                () -> assertThat(user).isNotEmpty(),
+                () -> assertThat(user.get().getAuthPlatform().getId()).isEqualTo(auth.getPlatform().getId()),
+                () -> assertThat(user.get().getAuthPlatform().getType()).isEqualTo(auth.getPlatform().getType()),
+                () -> assertThat(user.get().getStatus()).isEqualTo(UserStatus.PENDING)
+        );
+    }
+
+    @Test
+    void signIn을_요청한_이미_가입된_사용자는_isSignedUp이_true인_Auth_객체를_반환한다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        userRepository.save(DomainFixture.createUser());
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+
+        // then
+        assertAll(
+                () -> assertThat(auth.isSignedUp()).isTrue()
+        );
+    }
+
+    @Test
+    void signIn을_요청한_이미_가입된_사용자는_ACTIVE_상태다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        userRepository.save(DomainFixture.createUser());
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+        Optional<User> user = userRepository.findByPlatformId(auth.getPlatform().getId());
+
+        // then
+        assertAll(
+                () -> assertThat(user).isNotEmpty(),
+                () -> assertThat(user.get().getStatus()).isEqualTo(UserStatus.ACTIVE)
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthServiceIntegrationTest.java
@@ -29,9 +29,6 @@ class AuthServiceIntegrationTest {
     @Autowired
     private AuthService authService;
 
-    @Autowired
-    private AuthRepository authRepository;
-
     @MockBean
     private AuthPlatformServiceFactory authPlatformServiceFactory;
 
@@ -43,8 +40,6 @@ class AuthServiceIntegrationTest {
 
     @BeforeEach
     void init() {
-        authRepository.save(DomainFixture.createAuth(true));
-
         // AuthServiceImpl이 AuthPlatformService의 getPlatform()을 호출하면, FakeAuthKakaoPlatformServiceImpl의 getPlatform()이 호출된다.
         // 즉, DomainFixture.PLATFORM_ID와 AuthPlatform.Type.KAKAO가 반환된다.
         Mockito.when(authPlatformServiceFactory.getPlatformServiceFrom(Mockito.any(AuthPlatform.Type.class)))

--- a/src/test/java/org/recordy/server/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthServiceTest.java
@@ -1,0 +1,120 @@
+package org.recordy.server.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserStatus;
+import org.recordy.server.user.repository.UserRepository;
+import org.recordy.server.util.DomainFixture;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class AuthServiceTest {
+
+    private FakeContainer fakeContainer;
+
+    private AuthService authService;
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void init() {
+        fakeContainer = new FakeContainer();
+        authService = fakeContainer.authService;
+        userRepository = fakeContainer.userRepository;
+    }
+
+    @Test
+    void signIn을_요청한_가입되지_않은_사용자에_대해_새로운_User_객체가_저장된다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+        Optional<User> user = userRepository.findByPlatformId(auth.getPlatform().getId());
+
+        // then
+        assertAll(
+            () -> assertThat(user).isNotEmpty(),
+            () -> assertThat(user.get().getAuthPlatform().getId()).isEqualTo(auth.getPlatform().getId()),
+            () -> assertThat(user.get().getAuthPlatform().getType()).isEqualTo(auth.getPlatform().getType())
+        );
+    }
+
+    @Test
+    void signIn을_요청한_가입되지_않은_사용자는_isSignedUp이_false인_Auth_객체를_반환한다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+
+        // then
+        assertAll(
+                () -> assertThat(auth.isSignedUp()).isFalse()
+        );
+    }
+
+    @Test
+    void signIn을_요청한_가입되지_않은_사용자는_PENDING_상태로_가입_처리된다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+        Optional<User> user = userRepository.findByPlatformId(auth.getPlatform().getId());
+
+        // then
+        assertAll(
+                () -> assertThat(user).isNotEmpty(),
+                () -> assertThat(user.get().getAuthPlatform().getId()).isEqualTo(auth.getPlatform().getId()),
+                () -> assertThat(user.get().getAuthPlatform().getType()).isEqualTo(auth.getPlatform().getType()),
+                () -> assertThat(user.get().getStatus()).isEqualTo(UserStatus.PENDING)
+        );
+    }
+
+    @Test
+    void signIn을_요청한_이미_가입된_사용자는_isSignedUp이_true인_Auth_객체를_반환한다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        userRepository.save(DomainFixture.createUser());
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+
+        // then
+        assertAll(
+                () -> assertThat(auth.isSignedUp()).isTrue()
+        );
+    }
+
+    @Test
+    void signIn을_요청한_이미_가입된_사용자는_ACTIVE_상태다() {
+        // given
+        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
+
+        userRepository.save(DomainFixture.createUser());
+
+        // when
+        Auth auth = authService.signIn(authSignIn);
+        Optional<User> user = userRepository.findByPlatformId(auth.getPlatform().getId());
+
+        // then
+        assertAll(
+                () -> assertThat(user).isNotEmpty(),
+                () -> assertThat(user.get().getStatus()).isEqualTo(UserStatus.ACTIVE)
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthServiceTest.java
@@ -33,7 +33,7 @@ public class AuthServiceTest {
     @Test
     void signIn을_요청한_가입되지_않은_사용자에_대해_새로운_User_객체가_저장된다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         // when
@@ -51,7 +51,7 @@ public class AuthServiceTest {
     @Test
     void signIn을_요청한_가입되지_않은_사용자는_isSignedUp이_false인_Auth_객체를_반환한다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         // when
@@ -66,7 +66,7 @@ public class AuthServiceTest {
     @Test
     void signIn을_요청한_가입되지_않은_사용자는_PENDING_상태로_가입_처리된다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         // when
@@ -85,7 +85,7 @@ public class AuthServiceTest {
     @Test
     void signIn을_요청한_이미_가입된_사용자는_isSignedUp이_true인_Auth_객체를_반환한다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         userRepository.save(DomainFixture.createUser());
@@ -102,7 +102,7 @@ public class AuthServiceTest {
     @Test
     void signIn을_요청한_이미_가입된_사용자는_ACTIVE_상태다() {
         // given
-        AuthPlatform.Type platformType = DomainFixture.PLATFORM_TYPE;
+        AuthPlatform.Type platformType = DomainFixture.KAKAO_PLATFORM_TYPE;
         AuthSignIn authSignIn = DomainFixture.createAuthSignIn(platformType);
 
         userRepository.save(DomainFixture.createUser());

--- a/src/test/java/org/recordy/server/auth/service/AuthTokenServiceTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthTokenServiceTest.java
@@ -1,0 +1,47 @@
+package org.recordy.server.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.AuthToken;
+import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.util.DomainFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.recordy.server.auth.service.dto.AuthTokenValidationResult.*;
+
+public class AuthTokenServiceTest {
+
+    private FakeContainer fakeContainer;
+    private AuthTokenService authTokenService;
+
+    @BeforeEach
+    void init() {
+        fakeContainer = new FakeContainer();
+        authTokenService = fakeContainer.authTokenService;
+    }
+
+    @Test
+    void userId로부터_AuthToken_객체를_생성해서_반환한다() {
+        // given
+        long userId = DomainFixture.USER_ID;
+
+        // when
+        AuthToken authToken = authTokenService.issueToken(userId);
+
+        // then
+        assertAll(
+                () -> assertThat(authTokenService.validateToken(authToken.getAccessToken())).isEqualTo(VALID_JWT),
+                () -> assertThat(authTokenService.validateToken(authToken.getRefreshToken())).isEqualTo(VALID_JWT)
+        );
+    }
+
+    @Test
+    void 유효하지_않은_토큰을_검증하면_VALID_TOKEN을_반환하지_않는다() {
+        // given, when
+        String invalidToken = "invalidToken";
+
+        // then
+        assertThat(authTokenService.validateToken(invalidToken)).isNotEqualTo(VALID_JWT);
+    }
+}

--- a/src/test/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImplTest.java
@@ -25,7 +25,7 @@ public class AuthApplePlatformServiceImplTest {
     @Test
     void getPlatform을_통해_애플_플랫폼을_통한_사용자_정보를_조회한다() {
         // given
-        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.PLATFORM_TYPE);
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.APPLE_PLATFORM_TYPE);
 
         // when
         AuthPlatform platform = applePlatformService.getPlatform(authSignIn);
@@ -33,7 +33,7 @@ public class AuthApplePlatformServiceImplTest {
         // then
         assertAll(
                 () -> assertThat(platform.getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(platform.getType()).isEqualTo(DomainFixture.PLATFORM_TYPE)
+                () -> assertThat(platform.getType()).isEqualTo(DomainFixture.APPLE_PLATFORM_TYPE)
         );
     }
 }

--- a/src/test/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImplTest.java
@@ -1,0 +1,39 @@
+package org.recordy.server.auth.service.impl.apple;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.service.AuthPlatformService;
+import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.util.DomainFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class AuthApplePlatformServiceImplTest {
+
+    private FakeContainer fakeContainer;
+    private AuthPlatformService applePlatformService;
+
+    @BeforeEach
+    void init() {
+        fakeContainer = new FakeContainer();
+        applePlatformService = fakeContainer.authKakaoPlatformService;
+    }
+
+    @Test
+    void getPlatform을_통해_애플_플랫폼을_통한_사용자_정보를_조회한다() {
+        // given
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.PLATFORM_TYPE);
+
+        // when
+        AuthPlatform platform = applePlatformService.getPlatform(authSignIn);
+
+        // then
+        assertAll(
+                () -> assertThat(platform.getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(platform.getType()).isEqualTo(DomainFixture.PLATFORM_TYPE)
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImplTest.java
@@ -19,7 +19,7 @@ public class AuthApplePlatformServiceImplTest {
     @BeforeEach
     void init() {
         fakeContainer = new FakeContainer();
-        applePlatformService = fakeContainer.authKakaoPlatformService;
+        applePlatformService = fakeContainer.authApplePlatformService;
     }
 
     @Test

--- a/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
@@ -27,7 +27,7 @@ public class AuthKakaoPlatformServiceImplTest {
     @Test
     void getPlatform을_통해_카카오_플랫폼을_통한_사용자_정보를_조회한다() {
         // given
-        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.PLATFORM_TYPE);
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.KAKAO_PLATFORM_TYPE);
 
         // when
         AuthPlatform platform = kakaoPlatformService.getPlatform(authSignIn);
@@ -35,14 +35,14 @@ public class AuthKakaoPlatformServiceImplTest {
         // then
         assertAll(
                 () -> assertThat(platform.getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(platform.getType()).isEqualTo(DomainFixture.PLATFORM_TYPE)
+                () -> assertThat(platform.getType()).isEqualTo(DomainFixture.KAKAO_PLATFORM_TYPE)
         );
     }
 
     @Test
     void getPlatform을_통해_카카오_플랫폼에_존재하지_않는_사용자_정보를_조회한_경우_예외를_던진다() {
         // given
-        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.PLATFORM_TYPE);
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.KAKAO_PLATFORM_TYPE);
 
         // when, then
         assertThatThrownBy(() -> kakaoPlatformService.getPlatform(authSignIn))

--- a/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
@@ -1,0 +1,51 @@
+package org.recordy.server.auth.service.impl.kakao;
+
+import feign.FeignException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.service.AuthPlatformService;
+import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.util.DomainFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class AuthKakaoPlatformServiceImplTest {
+
+    private FakeContainer fakeContainer;
+    private AuthPlatformService kakaoPlatformService;
+
+    @BeforeEach
+    void init() {
+        fakeContainer = new FakeContainer();
+        kakaoPlatformService = fakeContainer.authKakaoPlatformService;
+    }
+
+    @Test
+    void getPlatform을_통해_카카오_플랫폼을_통한_사용자_정보를_조회한다() {
+        // given
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.PLATFORM_TYPE);
+
+        // when
+        AuthPlatform platform = kakaoPlatformService.getPlatform(authSignIn);
+
+        // then
+        assertAll(
+                () -> assertThat(platform.getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(platform.getType()).isEqualTo(DomainFixture.PLATFORM_TYPE)
+        );
+    }
+
+    @Test
+    void getPlatform을_통해_카카오_플랫폼에_존재하지_않는_사용자_정보를_조회한_경우_예외를_던진다() {
+        // given
+        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.PLATFORM_TYPE);
+
+        // when, then
+        assertThatThrownBy(() -> kakaoPlatformService.getPlatform(authSignIn))
+                .isInstanceOf(FeignException.class);
+    }
+}

--- a/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
@@ -42,7 +42,10 @@ public class AuthKakaoPlatformServiceImplTest {
     @Test
     void getPlatform을_통해_카카오_플랫폼에_존재하지_않는_사용자_정보를_조회한_경우_예외를_던진다() {
         // given
-        AuthSignIn authSignIn = DomainFixture.createAuthSignIn(DomainFixture.KAKAO_PLATFORM_TYPE);
+        AuthSignIn authSignIn = new AuthSignIn(
+                "invalid_token",
+                AuthPlatform.Type.KAKAO
+        );
 
         // when, then
         assertThatThrownBy(() -> kakaoPlatformService.getPlatform(authSignIn))

--- a/src/test/java/org/recordy/server/common/domain/JpaMetaInfoEntityTest.java
+++ b/src/test/java/org/recordy/server/common/domain/JpaMetaInfoEntityTest.java
@@ -1,0 +1,30 @@
+package org.recordy.server.common.domain;
+
+import org.junit.jupiter.api.Test;
+import org.recordy.server.user.domain.UserEntity;
+import org.recordy.server.user.repository.impl.UserJpaRepository;
+import org.recordy.server.util.DomainFixture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+class JpaMetaInfoEntityTest {
+
+    @Autowired
+    private UserJpaRepository userRepository;
+
+    @Test
+    void JpaMetaInfoEntity를_상속하는_엔티티는_DB에_저장할_때_생성일과_수정일을_가진다() {
+        // when
+        UserEntity userEntity = userRepository.save(DomainFixture.createUserEntity());
+
+        // then
+        assertAll(
+                () -> assertThat(userEntity.createdAt).isNotNull(),
+                () -> assertThat(userEntity.updatedAt).isNotNull()
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/mock/FakeContainer.java
+++ b/src/test/java/org/recordy/server/mock/FakeContainer.java
@@ -1,0 +1,43 @@
+package org.recordy.server.mock;
+
+import org.recordy.server.auth.repository.AuthRepository;
+import org.recordy.server.auth.service.AuthPlatformService;
+import org.recordy.server.auth.service.AuthService;
+import org.recordy.server.auth.service.AuthTokenService;
+import org.recordy.server.auth.service.impl.AuthPlatformServiceImpl;
+import org.recordy.server.auth.service.impl.AuthServiceImpl;
+import org.recordy.server.auth.service.impl.AuthTokenServiceImpl;
+import org.recordy.server.mock.auth.FakeAuthRepository;
+import org.recordy.server.mock.user.FakeUserRepository;
+import org.recordy.server.user.controller.UserController;
+import org.recordy.server.user.repository.UserRepository;
+import org.recordy.server.user.service.UserService;
+import org.recordy.server.user.service.impl.UserServiceImpl;
+
+public class FakeContainer {
+
+    // repository
+    public final UserRepository userRepository;
+    public final AuthRepository authRepository;
+
+    // service
+    public final UserService userService;
+    public final AuthPlatformService authPlatformService;
+    public final AuthTokenService authTokenService;
+    public final AuthService authService;
+
+    // controller
+    public final UserController userController;
+
+    public FakeContainer() {
+        this.userRepository = new FakeUserRepository();
+        this.authRepository = new FakeAuthRepository();
+
+        this.userService = new UserServiceImpl(userRepository);
+        this.authPlatformService = new AuthPlatformServiceImpl();
+        this.authTokenService = new AuthTokenServiceImpl();
+        this.authService = new AuthServiceImpl(authRepository, authPlatformService, authTokenService, userService);
+
+        this.userController = new UserController(authService);
+    }
+}

--- a/src/test/java/org/recordy/server/mock/FakeContainer.java
+++ b/src/test/java/org/recordy/server/mock/FakeContainer.java
@@ -2,9 +2,11 @@ package org.recordy.server.mock;
 
 import org.recordy.server.auth.repository.AuthRepository;
 import org.recordy.server.auth.service.AuthPlatformService;
+import org.recordy.server.auth.service.AuthPlatformServiceFactory;
 import org.recordy.server.auth.service.AuthService;
 import org.recordy.server.auth.service.AuthTokenService;
-import org.recordy.server.auth.service.impl.AuthPlatformServiceImpl;
+import org.recordy.server.auth.service.impl.apple.AuthApplePlatformServiceImpl;
+import org.recordy.server.auth.service.impl.kakao.AuthKakaoPlatformServiceImpl;
 import org.recordy.server.auth.service.impl.AuthServiceImpl;
 import org.recordy.server.auth.service.impl.AuthTokenServiceImpl;
 import org.recordy.server.mock.auth.FakeAuthRepository;
@@ -14,6 +16,8 @@ import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.user.service.UserService;
 import org.recordy.server.user.service.impl.UserServiceImpl;
 
+import java.util.List;
+
 public class FakeContainer {
 
     // repository
@@ -22,7 +26,9 @@ public class FakeContainer {
 
     // service
     public final UserService userService;
-    public final AuthPlatformService authPlatformService;
+    public final AuthPlatformService authKakaoPlatformService;
+    public final AuthPlatformService authApplePlatformService;
+    public final AuthPlatformServiceFactory authPlatformServiceFactory;
     public final AuthTokenService authTokenService;
     public final AuthService authService;
 
@@ -34,9 +40,11 @@ public class FakeContainer {
         this.authRepository = new FakeAuthRepository();
 
         this.userService = new UserServiceImpl(userRepository);
-        this.authPlatformService = new AuthPlatformServiceImpl();
+        this.authKakaoPlatformService = new AuthKakaoPlatformServiceImpl();
+        this.authApplePlatformService = new AuthApplePlatformServiceImpl();
+        this.authPlatformServiceFactory = new AuthPlatformServiceFactory(List.of(authKakaoPlatformService, authApplePlatformService));
         this.authTokenService = new AuthTokenServiceImpl();
-        this.authService = new AuthServiceImpl(authRepository, authPlatformService, authTokenService, userService);
+        this.authService = new AuthServiceImpl(authRepository, authPlatformServiceFactory, authTokenService, userService);
 
         this.userController = new UserController(authService);
     }

--- a/src/test/java/org/recordy/server/mock/FakeContainer.java
+++ b/src/test/java/org/recordy/server/mock/FakeContainer.java
@@ -5,10 +5,10 @@ import org.recordy.server.auth.service.AuthPlatformService;
 import org.recordy.server.auth.service.AuthPlatformServiceFactory;
 import org.recordy.server.auth.service.AuthService;
 import org.recordy.server.auth.service.AuthTokenService;
-import org.recordy.server.auth.service.impl.apple.AuthApplePlatformServiceImpl;
-import org.recordy.server.auth.service.impl.kakao.AuthKakaoPlatformServiceImpl;
 import org.recordy.server.auth.service.impl.AuthServiceImpl;
 import org.recordy.server.auth.service.impl.AuthTokenServiceImpl;
+import org.recordy.server.mock.auth.FakeAuthApplePlatformServiceImpl;
+import org.recordy.server.mock.auth.FakeAuthKakaoPlatformServiceImpl;
 import org.recordy.server.mock.auth.FakeAuthRepository;
 import org.recordy.server.mock.user.FakeUserRepository;
 import org.recordy.server.user.controller.UserController;
@@ -40,8 +40,8 @@ public class FakeContainer {
         this.authRepository = new FakeAuthRepository();
 
         this.userService = new UserServiceImpl(userRepository);
-        this.authKakaoPlatformService = new AuthKakaoPlatformServiceImpl();
-        this.authApplePlatformService = new AuthApplePlatformServiceImpl();
+        this.authKakaoPlatformService = new FakeAuthKakaoPlatformServiceImpl();
+        this.authApplePlatformService = new FakeAuthApplePlatformServiceImpl();
         this.authPlatformServiceFactory = new AuthPlatformServiceFactory(List.of(authKakaoPlatformService, authApplePlatformService));
         this.authTokenService = new AuthTokenServiceImpl();
         this.authService = new AuthServiceImpl(authRepository, authPlatformServiceFactory, authTokenService, userService);

--- a/src/test/java/org/recordy/server/mock/auth/FakeAuthApplePlatformServiceImpl.java
+++ b/src/test/java/org/recordy/server/mock/auth/FakeAuthApplePlatformServiceImpl.java
@@ -1,0 +1,22 @@
+package org.recordy.server.mock.auth;
+
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.service.AuthPlatformService;
+import org.recordy.server.util.DomainFixture;
+
+public class FakeAuthApplePlatformServiceImpl implements AuthPlatformService {
+
+    @Override
+    public AuthPlatform getPlatform(AuthSignIn authSignIn) {
+        return new AuthPlatform(
+                DomainFixture.PLATFORM_ID,
+                AuthPlatform.Type.APPLE
+        );
+    }
+
+    @Override
+    public AuthPlatform.Type getPlatformType() {
+        return AuthPlatform.Type.APPLE;
+    }
+}

--- a/src/test/java/org/recordy/server/mock/auth/FakeAuthKakaoPlatformServiceImpl.java
+++ b/src/test/java/org/recordy/server/mock/auth/FakeAuthKakaoPlatformServiceImpl.java
@@ -1,0 +1,22 @@
+package org.recordy.server.mock.auth;
+
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
+import org.recordy.server.auth.service.AuthPlatformService;
+import org.recordy.server.util.DomainFixture;
+
+public class FakeAuthKakaoPlatformServiceImpl implements AuthPlatformService {
+
+    @Override
+    public AuthPlatform getPlatform(AuthSignIn authSignIn) {
+        return new AuthPlatform(
+                DomainFixture.PLATFORM_ID,
+                AuthPlatform.Type.KAKAO
+        );
+    }
+
+    @Override
+    public AuthPlatform.Type getPlatformType() {
+        return AuthPlatform.Type.KAKAO;
+    }
+}

--- a/src/test/java/org/recordy/server/mock/auth/FakeAuthRepository.java
+++ b/src/test/java/org/recordy/server/mock/auth/FakeAuthRepository.java
@@ -1,0 +1,19 @@
+package org.recordy.server.mock.auth;
+
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.repository.AuthRepository;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FakeAuthRepository implements AuthRepository {
+
+    private final Map<String, Auth> auths = new HashMap<>();
+
+    @Override
+    public Auth save(Auth auth) {
+        auths.put(auth.getPlatform().getId(), auth);
+
+        return auth;
+    }
+}

--- a/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
+++ b/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
@@ -9,14 +9,18 @@ import java.util.Optional;
 
 public class FakeUserRepository implements UserRepository {
 
-    private long autoIncrementId = 1L;
-    private final Map<Long, User> users = new HashMap<>();
+    public long autoIncrementId = 1L;
+    public final Map<Long, User> users = new HashMap<>();
 
     @Override
     public User save(User user) {
-        users.put(user.getId(), user);
+        users.put(autoIncrementId, user);
 
-        return user;
+        return User.builder()
+                .id(autoIncrementId++)
+                .authPlatform(user.getAuthPlatform())
+                .status(user.getStatus())
+                .build();
     }
 
     @Override

--- a/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
+++ b/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
@@ -1,0 +1,28 @@
+package org.recordy.server.mock.user;
+
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.repository.UserRepository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeUserRepository implements UserRepository {
+
+    private long autoIncrementId = 1L;
+    private final Map<Long, User> users = new HashMap<>();
+
+    @Override
+    public User save(User user) {
+        users.put(user.getId(), user);
+
+        return user;
+    }
+
+    @Override
+    public Optional<User> findByPlatformId(String platformId) {
+        return users.values().stream()
+                .filter(user -> user.getAuthPlatform().getId().equals(platformId))
+                .findFirst();
+    }
+}

--- a/src/test/java/org/recordy/server/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/org/recordy/server/user/controller/UserControllerIntegrationTest.java
@@ -1,0 +1,80 @@
+package org.recordy.server.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.user.controller.dto.request.UserSignInRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@SqlGroup({
+        @Sql(value = "/sql/user-service-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/user-service-test-clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+})
+@AutoConfigureMockMvc
+class UserControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void signIn을_통해_사용자는_카카오_플랫폼_토큰을_통해_가입_이후_토큰을_반환받을_수_있다() throws Exception {
+        // given
+        String request = objectMapper.writeValueAsString(new UserSignInRequest(AuthPlatform.Type.KAKAO));
+
+        // when
+        mockMvc.perform(post("/api/v1/users/signIn")
+                        .contentType("application/json")
+                        .header("Authorization", "Bearer " + "token")
+                        .content(request))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(jsonPath("$.isSignedUp").value(false));
+    }
+
+    @Test
+    void signIn을_통해_사용자는_애플_플랫폼_토큰을_통해_가입_이후_토큰을_반환받을_수_있다() throws Exception {
+        // given
+        String request = objectMapper.writeValueAsString(new UserSignInRequest(AuthPlatform.Type.KAKAO));
+
+        // when
+        mockMvc.perform(post("/api/v1/users/signIn")
+                        .contentType("application/json")
+                        .header("Authorization", "Bearer " + "token")
+                        .content(request))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(jsonPath("$.isSignedUp").value(false));
+    }
+
+    @Test
+    void Authorization_헤더가_비어_있을_경우_400을_반환한다() throws Exception {
+        // given
+        String request = objectMapper.writeValueAsString(new UserSignInRequest(AuthPlatform.Type.KAKAO));
+
+        // when
+        mockMvc.perform(post("/api/v1/users/signIn")
+                        .contentType("application/json")
+                        .content(request))
+
+                // then
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/org/recordy/server/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/org/recordy/server/user/controller/UserControllerIntegrationTest.java
@@ -49,7 +49,7 @@ class UserControllerIntegrationTest {
     @Test
     void signIn을_통해_사용자는_애플_플랫폼_토큰을_통해_가입_이후_토큰을_반환받을_수_있다() throws Exception {
         // given
-        String request = objectMapper.writeValueAsString(new UserSignInRequest(AuthPlatform.Type.KAKAO));
+        String request = objectMapper.writeValueAsString(new UserSignInRequest(AuthPlatform.Type.APPLE));
 
         // when
         mockMvc.perform(post("/api/v1/users/signIn")

--- a/src/test/java/org/recordy/server/user/controller/UserControllerTest.java
+++ b/src/test/java/org/recordy/server/user/controller/UserControllerTest.java
@@ -1,0 +1,61 @@
+package org.recordy.server.user.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.user.controller.dto.request.UserSignInRequest;
+import org.recordy.server.user.controller.dto.response.UserSignInResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class UserControllerTest {
+
+    private FakeContainer fakeContainer;
+    private UserController userController;
+
+    @BeforeEach
+    void init() {
+        fakeContainer = new FakeContainer();
+        userController = fakeContainer.userController;
+    }
+
+    @Test
+    void signIn을_통해_사용자는_카카오_플랫폼_토큰을_통해_가입_이후_토큰을_반환받을_수_있다() {
+        // given
+        String platformToken = "platform_token";
+        UserSignInRequest request = new UserSignInRequest(AuthPlatform.Type.KAKAO);
+
+        // when
+        ResponseEntity<UserSignInResponse> result = userController.signIn(platformToken, request);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(result.getBody().accessToken()).isNotNull(),
+                () -> assertThat(result.getBody().refreshToken()).isNotNull(),
+                () -> assertThat(result.getBody().isSignedUp()).isFalse()
+        );
+    }
+
+    @Test
+    void signIn을_통해_사용자는_애플_플랫폼_토큰을_통해_가입_이후_토큰을_반환받을_수_있다() {
+        // given
+        String platformToken = "platform_token";
+        UserSignInRequest request = new UserSignInRequest(AuthPlatform.Type.APPLE);
+
+        // when
+        ResponseEntity<UserSignInResponse> result = userController.signIn(platformToken, request);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(result.getBody().accessToken()).isNotNull(),
+                () -> assertThat(result.getBody().refreshToken()).isNotNull(),
+                () -> assertThat(result.getBody().isSignedUp()).isFalse()
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/user/controller/dto/response/UserSignInResponseTest.java
+++ b/src/test/java/org/recordy/server/user/controller/dto/response/UserSignInResponseTest.java
@@ -1,0 +1,27 @@
+package org.recordy.server.user.controller.dto.response;
+
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.util.DomainFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class UserSignInResponseTest {
+
+    @Test
+    void from을_통해_Auth_객체로부터_UserSignInResponse_객체를_생성할_수_있다() {
+        // given
+        Auth auth = DomainFixture.createAuth(false);
+
+        // when
+        UserSignInResponse userSignInResponse = UserSignInResponse.from(auth);
+
+        // then
+        assertAll(
+                () -> assertThat(userSignInResponse.accessToken()).isEqualTo(auth.getToken().getAccessToken()),
+                () -> assertThat(userSignInResponse.refreshToken()).isEqualTo(auth.getToken().getRefreshToken()),
+                () -> assertThat(userSignInResponse.isSignedUp()).isEqualTo(auth.isSignedUp())
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/user/domain/UserEntityTest.java
+++ b/src/test/java/org/recordy/server/user/domain/UserEntityTest.java
@@ -1,0 +1,69 @@
+package org.recordy.server.user.domain;
+
+import org.junit.jupiter.api.Test;
+import org.recordy.server.util.DomainFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class UserEntityTest {
+
+    @Test
+    void from을_통해_User_객체로부터_UserEntity_객체를_생성할_수_있다() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .authPlatform(DomainFixture.createAuthPlatform())
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        // when
+        UserEntity userEntity = UserEntity.from(user);
+
+        // then
+        assertAll(
+                () -> assertThat(userEntity.getId()).isEqualTo(user.getId()),
+                () -> assertThat(userEntity.getPlatformId()).isEqualTo(user.getAuthPlatform().getId()),
+                () -> assertThat(userEntity.getPlatformType()).isEqualTo(user.getAuthPlatform().getType()),
+                () -> assertThat(userEntity.getStatus()).isEqualTo(user.getStatus())
+        );
+    }
+
+    @Test
+    void from을_통해_넘어온_User_객체의_id_필드가_null일_수_있다() {
+        // given
+        User user = User.builder()
+                .id(null)
+                .authPlatform(DomainFixture.createAuthPlatform())
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        // when
+        UserEntity userEntity = UserEntity.from(user);
+
+        // then
+        assertAll(
+                () -> assertThat(userEntity.getId()).isEqualTo(null),
+                () -> assertThat(userEntity.getPlatformId()).isEqualTo(user.getAuthPlatform().getId()),
+                () -> assertThat(userEntity.getPlatformType()).isEqualTo(user.getAuthPlatform().getType()),
+                () -> assertThat(userEntity.getStatus()).isEqualTo(user.getStatus())
+        );
+    }
+
+    @Test
+    void toDomain을_통해_UserEntity_객체로부터_User_객체를_생성할_수_있다() {
+        // given
+        UserEntity userEntity = DomainFixture.createUserEntity();
+
+        // when
+        User user = userEntity.toDomain();
+
+        // then
+        assertAll(
+                () -> assertThat(user.getId()).isEqualTo(userEntity.getId()),
+                () -> assertThat(user.getAuthPlatform().getId()).isEqualTo(userEntity.getPlatformId()),
+                () -> assertThat(user.getAuthPlatform().getType()).isEqualTo(userEntity.getPlatformType()),
+                () -> assertThat(user.getStatus()).isEqualTo(userEntity.getStatus())
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/user/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/org/recordy/server/user/repository/UserRepositoryIntegrationTest.java
@@ -1,0 +1,65 @@
+package org.recordy.server.user.repository;
+
+import org.junit.jupiter.api.Test;
+import org.recordy.server.util.DomainFixture;
+import org.recordy.server.user.domain.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SqlGroup({
+        @Sql(value = "/sql/user-repository-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/user-repository-test-clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+})
+@SpringBootTest
+class UserRepositoryIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void save를_통해_유저_데이터를_저장할_수_있다() {
+        // given
+        User user = DomainFixture.createUser();
+
+        // when
+        User result = userRepository.save(user);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getId()).isNotNull(),
+                () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(result.getStatus()).isEqualTo(DomainFixture.DEFAULT_USER_STATUS)
+        );
+    }
+
+    @Test
+    void findByPlatformId를_통해_플랫폼_ID로_유저_데이터를_조회할_수_있다() {
+        // when
+        User result = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID).orElse(null);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getId()).isNotNull(),
+                () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(result.getStatus()).isEqualTo(DomainFixture.DEFAULT_USER_STATUS)
+        );
+    }
+
+    @Test
+    void findByPlatformId를_통해_존재하지_않는_플랫폼_ID로_유저_데이터를_조회하면_빈_값을_반환한다() {
+        // when
+        Optional<User> result = userRepository.findByPlatformId("non-exist-platform-id");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/org/recordy/server/user/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/org/recordy/server/user/repository/UserRepositoryIntegrationTest.java
@@ -35,7 +35,7 @@ class UserRepositoryIntegrationTest {
         assertAll(
                 () -> assertThat(result.getId()).isNotNull(),
                 () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.KAKAO_PLATFORM_TYPE),
                 () -> assertThat(result.getStatus()).isEqualTo(DomainFixture.DEFAULT_USER_STATUS)
         );
     }
@@ -49,7 +49,7 @@ class UserRepositoryIntegrationTest {
         assertAll(
                 () -> assertThat(result.getId()).isNotNull(),
                 () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.KAKAO_PLATFORM_TYPE),
                 () -> assertThat(result.getStatus()).isEqualTo(DomainFixture.DEFAULT_USER_STATUS)
         );
     }

--- a/src/test/java/org/recordy/server/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/org/recordy/server/user/service/UserServiceIntegrationTest.java
@@ -37,7 +37,7 @@ class UserServiceIntegrationTest {
         assertAll(
                 () -> assertThat(user.getId()).isNotNull(),
                 () -> assertThat(user.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(user.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(user.getAuthPlatform().getType()).isEqualTo(DomainFixture.KAKAO_PLATFORM_TYPE),
                 () -> assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING)
         );
     }
@@ -51,7 +51,7 @@ class UserServiceIntegrationTest {
         assertAll(
                 () -> assertThat(result.getId()).isNotNull(),
                 () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.KAKAO_PLATFORM_TYPE),
                 () -> assertThat(result.getStatus()).isEqualTo(DomainFixture.DEFAULT_USER_STATUS)
         );
     }

--- a/src/test/java/org/recordy/server/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/org/recordy/server/user/service/UserServiceIntegrationTest.java
@@ -1,0 +1,67 @@
+package org.recordy.server.user.service;
+
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserStatus;
+import org.recordy.server.util.DomainFixture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@SqlGroup({
+        @Sql(value = "/sql/user-service-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/user-service-test-clean.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+})
+class UserServiceIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    void create을_통해_플랫폼_정보와_사용자_상태로부터_PENDING_상태의_사용자를_생성할_수_있다() {
+        // given
+        AuthPlatform authPlatform = DomainFixture.createAuthPlatform();
+
+        // when
+        User user = userService.create(authPlatform);
+
+        // then
+        assertAll(
+                () -> assertThat(user.getId()).isNotNull(),
+                () -> assertThat(user.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(user.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING)
+        );
+    }
+
+    @Test
+    void getByPlatformId를_통해_플랫폼_ID로_사용자_데이터를_조회할_수_있다() {
+        // when
+        User result = userService.getByPlatformId(DomainFixture.PLATFORM_ID).orElse(null);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getId()).isNotNull(),
+                () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(result.getStatus()).isEqualTo(DomainFixture.DEFAULT_USER_STATUS)
+        );
+    }
+
+    @Test
+    void getByPlatformId를_통해_존재하지_않는_플랫폼_ID로_사용자_데이터를_조회하면_빈_값을_반환한다() {
+        // when
+        Optional<User> user = userService.getByPlatformId("non-exist-platform-id");
+
+        // then
+        assertThat(user).isEmpty();
+    }
+}

--- a/src/test/java/org/recordy/server/user/service/UserServiceTest.java
+++ b/src/test/java/org/recordy/server/user/service/UserServiceTest.java
@@ -1,0 +1,71 @@
+package org.recordy.server.user.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserStatus;
+import org.recordy.server.user.repository.UserRepository;
+import org.recordy.server.util.DomainFixture;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class UserServiceTest {
+
+    private FakeContainer fakeContainer;
+
+    private UserService userService;
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void init() {
+        fakeContainer = new FakeContainer();
+        userService = fakeContainer.userService;
+        userRepository = fakeContainer.userRepository;
+
+        userRepository.save(DomainFixture.createUser());
+    }
+
+    @Test
+    void create을_통해_플랫폼_정보와_사용자_상태로부터_PENDING_상태의_사용자를_생성할_수_있다() {
+        // given
+        AuthPlatform authPlatform = DomainFixture.createAuthPlatform();
+
+        // when
+        User user = userService.create(authPlatform);
+
+        // then
+        assertAll(
+                () -> assertThat(user.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(user.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING)
+        );
+    }
+
+    @Test
+    void getByPlatformId를_통해_플랫폼_ID로_사용자_데이터를_조회할_수_있다() {
+        // when
+        User result = userService.getByPlatformId(DomainFixture.PLATFORM_ID).orElse(null);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getId()).isNotNull(),
+                () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(result.getStatus()).isEqualTo(DomainFixture.DEFAULT_USER_STATUS)
+        );
+    }
+
+    @Test
+    void getByPlatformId를_통해_존재하지_않는_플랫폼_ID로_사용자_데이터를_조회하면_빈_값을_반환한다() {
+        // when
+        Optional<User> user = userService.getByPlatformId("non-exist-platform-id");
+
+        // then
+        assertThat(user).isEmpty();
+    }
+}

--- a/src/test/java/org/recordy/server/user/service/UserServiceTest.java
+++ b/src/test/java/org/recordy/server/user/service/UserServiceTest.java
@@ -41,7 +41,7 @@ public class UserServiceTest {
         // then
         assertAll(
                 () -> assertThat(user.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(user.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(user.getAuthPlatform().getType()).isEqualTo(DomainFixture.KAKAO_PLATFORM_TYPE),
                 () -> assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING)
         );
     }
@@ -55,7 +55,7 @@ public class UserServiceTest {
         assertAll(
                 () -> assertThat(result.getId()).isNotNull(),
                 () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.PLATFORM_TYPE),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(DomainFixture.KAKAO_PLATFORM_TYPE),
                 () -> assertThat(result.getStatus()).isEqualTo(DomainFixture.DEFAULT_USER_STATUS)
         );
     }

--- a/src/test/java/org/recordy/server/util/DomainFixture.java
+++ b/src/test/java/org/recordy/server/util/DomainFixture.java
@@ -1,0 +1,54 @@
+package org.recordy.server.util;
+
+import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.domain.AuthToken;
+import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.UserEntity;
+import org.recordy.server.user.domain.UserStatus;
+
+public final class DomainFixture {
+
+    public static final String PLATFORM_ID = "abcdefg";
+    public static final AuthPlatform.Type PLATFORM_TYPE = AuthPlatform.Type.KAKAO;
+    public static final String ACCESS_TOKEN = "access_token";
+    public static final String REFRESH_TOKEN = "refresh_token";
+    public static final Long USER_ID = 1L;
+    public static final UserStatus DEFAULT_USER_STATUS = UserStatus.ACTIVE;
+
+    public static AuthPlatform createAuthPlatform() {
+        return new AuthPlatform(PLATFORM_ID, PLATFORM_TYPE);
+    }
+
+    public static AuthToken createAuthToken() {
+        return new AuthToken(
+                ACCESS_TOKEN,
+                REFRESH_TOKEN
+        );
+    }
+
+    public static Auth createAuth(boolean isSignedUp) {
+        return new Auth(
+                createAuthPlatform(),
+                createAuthToken(),
+                isSignedUp
+        );
+    }
+
+    public static UserEntity createUserEntity() {
+        return new UserEntity(
+                USER_ID,
+                PLATFORM_ID,
+                PLATFORM_TYPE,
+                DEFAULT_USER_STATUS
+        );
+    }
+
+    public static User createUser() {
+        return User.builder()
+                .id(USER_ID)
+                .authPlatform(createAuthPlatform())
+                .status(DEFAULT_USER_STATUS)
+                .build();
+    }
+}

--- a/src/test/java/org/recordy/server/util/DomainFixture.java
+++ b/src/test/java/org/recordy/server/util/DomainFixture.java
@@ -13,14 +13,15 @@ public final class DomainFixture {
 
     public static final String PLATFORM_TOKEN = "platform_token";
     public static final String PLATFORM_ID = "abcdefg";
-    public static final AuthPlatform.Type PLATFORM_TYPE = AuthPlatform.Type.KAKAO;
+    public static final AuthPlatform.Type KAKAO_PLATFORM_TYPE = AuthPlatform.Type.KAKAO;
+    public static final AuthPlatform.Type APPLE_PLATFORM_TYPE = AuthPlatform.Type.APPLE;
     public static final String ACCESS_TOKEN = "access_token";
     public static final String REFRESH_TOKEN = "refresh_token";
     public static final Long USER_ID = 1L;
     public static final UserStatus DEFAULT_USER_STATUS = UserStatus.ACTIVE;
 
     public static AuthPlatform createAuthPlatform() {
-        return new AuthPlatform(PLATFORM_ID, PLATFORM_TYPE);
+        return new AuthPlatform(PLATFORM_ID, KAKAO_PLATFORM_TYPE);
     }
 
     public static AuthToken createAuthToken() {
@@ -48,7 +49,7 @@ public final class DomainFixture {
     public static AuthEntity createAuthEntity(boolean isSignedUp) {
         return new AuthEntity(
                 PLATFORM_ID,
-                PLATFORM_TYPE.name(),
+                KAKAO_PLATFORM_TYPE.name(),
                 ACCESS_TOKEN,
                 REFRESH_TOKEN,
                 isSignedUp
@@ -67,7 +68,7 @@ public final class DomainFixture {
         return new UserEntity(
                 USER_ID,
                 PLATFORM_ID,
-                PLATFORM_TYPE,
+                KAKAO_PLATFORM_TYPE,
                 DEFAULT_USER_STATUS
         );
     }

--- a/src/test/java/org/recordy/server/util/DomainFixture.java
+++ b/src/test/java/org/recordy/server/util/DomainFixture.java
@@ -1,14 +1,17 @@
 package org.recordy.server.util;
 
 import org.recordy.server.auth.domain.Auth;
+import org.recordy.server.auth.domain.AuthEntity;
 import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.auth.domain.AuthToken;
+import org.recordy.server.auth.domain.usecase.AuthSignIn;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.UserEntity;
 import org.recordy.server.user.domain.UserStatus;
 
 public final class DomainFixture {
 
+    public static final String PLATFORM_TOKEN = "platform_token";
     public static final String PLATFORM_ID = "abcdefg";
     public static final AuthPlatform.Type PLATFORM_TYPE = AuthPlatform.Type.KAKAO;
     public static final String ACCESS_TOKEN = "access_token";
@@ -27,6 +30,13 @@ public final class DomainFixture {
         );
     }
 
+    public static AuthSignIn createAuthSignIn(AuthPlatform.Type platformType) {
+        return new AuthSignIn(
+                PLATFORM_TOKEN,
+                platformType
+        );
+    }
+
     public static Auth createAuth(boolean isSignedUp) {
         return new Auth(
                 createAuthPlatform(),
@@ -35,12 +45,13 @@ public final class DomainFixture {
         );
     }
 
-    public static UserEntity createUserEntity() {
-        return new UserEntity(
-                USER_ID,
+    public static AuthEntity createAuthEntity(boolean isSignedUp) {
+        return new AuthEntity(
                 PLATFORM_ID,
-                PLATFORM_TYPE,
-                DEFAULT_USER_STATUS
+                PLATFORM_TYPE.name(),
+                ACCESS_TOKEN,
+                REFRESH_TOKEN,
+                isSignedUp
         );
     }
 
@@ -50,5 +61,14 @@ public final class DomainFixture {
                 .authPlatform(createAuthPlatform())
                 .status(DEFAULT_USER_STATUS)
                 .build();
+    }
+
+    public static UserEntity createUserEntity() {
+        return new UserEntity(
+                USER_ID,
+                PLATFORM_ID,
+                PLATFORM_TYPE,
+                DEFAULT_USER_STATUS
+        );
     }
 }

--- a/src/test/resources/sql/user-repository-test-clean.sql
+++ b/src/test/resources/sql/user-repository-test-clean.sql
@@ -1,0 +1,1 @@
+delete from `users` where 1;

--- a/src/test/resources/sql/user-repository-test-data.sql
+++ b/src/test/resources/sql/user-repository-test-data.sql
@@ -1,0 +1,2 @@
+insert into `users` (`id`, `platform_id`, `platform_type`, `status`)
+values (1, 'abcdefg', 'KAKAO', 'ACTIVE');

--- a/src/test/resources/sql/user-service-test-clean.sql
+++ b/src/test/resources/sql/user-service-test-clean.sql
@@ -1,0 +1,1 @@
+delete from `users` where 1;

--- a/src/test/resources/sql/user-service-test-data.sql
+++ b/src/test/resources/sql/user-service-test-data.sql
@@ -1,0 +1,2 @@
+insert into `users` (`id`, `platform_id`, `platform_type`, `status`)
+values (1, 'abcdefg', 'KAKAO', 'ACTIVE');


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: #1 

&nbsp;

## 👷 **작업한 내용**
- Auth 도메인
  - `UserController`로부터 직접적으로 로그인을 요청받는 `AuthService` 및 구현체인 `AuthServiceImpl` 정의
    - `UserService`에 의존하여 사용자를 조회하고, 등록되어 있지 않은 경우 등록을 요청하는 행동
    - `Auth` 객체를 저장하는 행동
  - 플랫폼 서비스를 통해 사용자 정보를 조회하는 `AuthPlatformService` 정의
    - APPLE, KAKAO에 대한 각각의 구현체 `AuthApplePlatformServiceImpl`, `AuthKakaoPlatformServiceImpl` 정의
    - 각 구현체를 알맞게 제공하는 `PlatformServiceFactory`
  - 토큰을 생성하고 검증하는 `AuthTokenService` 정의
    - 토큰 검증의 결과인 `AuthTokenValidationResult` 정의
  - `AuthRepository` 정의
    - 구현체인 `AuthRepositoryImpl` 정의
    - CrudRepository를 상속하는 `AuthJpaRepository` 정의
  - `Auth` 도메인 정의
    - Redis에 저장하기 위한 `AuthEntity` 정의
    - 플랫폼에 대한 `AuthPlatform` 도메인 정의
    - 토큰에 대한 `AuthToken` 도메인 정의
    - 사용자의 인증 정보로 로그인하는 유스케이스 `AuthSignIn` 정의

&nbsp;

- User 도메인
  - `UserService` 및 구현체 `UserServiceImpl` 정의
    - User 객체를 생성하는 행동
    - 플랫폼 정보로부터 User 객체를 조회하는 행동
  - `UserRepository` 정의
    - 구현체인 `UserRepositoryImpl` 정의
    - JpaRepository를 상속하는 `UserJpaRepository` 정의
  - `User` 도메인 정의
    - Jpa를 통해 DB에 저장하기 위한 `UserEntity` 정의
    - 소셜 로그인에 통과했으나 프로필 설정이 완료되지 않은 유스케이스를 고려한 `UserStatus` 정의
  - `UserController` 정의
    - signIn을 통해 사용자를 로그인(+ 가입)시키는 행동
    - signIn과 관련한 request, response 정의
    - `UserApi`는 스웨거를 활용한 API 문서 작성을 위해 정의

&nbsp;

- Auth, User 도메인과 관련한 테스트 추가
- 테스트 커버리지 첨부
<img width="660" alt="스크린샷 2024-06-25 오전 1 49 09" src="https://github.com/Team-Recordy/Recordy-Server/assets/137763434/7dfa468b-9208-49a9-8d80-fbe76646b64f">


&nbsp;

## 🚨 참고 사항
- 네이밍의 prefix는 도메인에 맞추기 위해 노력했습니다...
  - 그 결과 `AuthApplePlatformServiceImpl`과 같은 긴 이름이 탄생했습니다...
  - 그래서 혹시 이름이 너무 길다면 대안을 제시해주셔도 좋습니다...
- 도메인을 순수한 자바 객체로 남기기 위해 노력했습니다...
  - 그 결과 우리가 알던 익숙한 어노테이션이 붙은 Jpa 코드는 UserEntity, AuthEntity로 분리되었습니다
- 테스트와 관련한 내용은 따로 적어두지 않았지만 질문은 언제든지 환영입니다 !!

![user login usecase diagram](https://github.com/Team-Recordy/Recordy-Server/assets/137763434/f728531d-de67-464e-a236-fd2480057466)
