### PR TITLE
[refactor] bookmark, follow 등록/삭제 API 엔드포인트 통일

### DIFF
--- a/src/main/java/org/recordy/server/auth/service/AuthTokenService.java
+++ b/src/main/java/org/recordy/server/auth/service/AuthTokenService.java
@@ -12,4 +12,5 @@ public interface AuthTokenService {
     String getTokenFromRequest(HttpServletRequest request);
     long getUserIdFromToken(String token);
     String issueAccessToken(long userId);
+    String removePrefix(String value);
 }

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
@@ -25,6 +25,7 @@ public class AuthServiceImpl implements AuthService {
     private final AuthRepository authRepository;
     private final AuthPlatformServiceFactory platformServiceFactory;
     private final AuthTokenService authTokenService;
+
     @Override
     public Auth create(User user, AuthPlatform platform) {
         AuthToken token = authTokenService.issueToken(user.getId());
@@ -46,8 +47,9 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public AuthPlatform getPlatform(UserSignIn userSignIn) {
+        String platformToken = authTokenService.removePrefix(userSignIn.platformToken());
         AuthPlatformService platformService = platformServiceFactory.getPlatformServiceFrom(userSignIn.platformType());
 
-        return platformService.getPlatform(userSignIn);
+        return platformService.getPlatform(new UserSignIn(platformToken, userSignIn.platformType()));
     }
 }

--- a/src/main/java/org/recordy/server/auth/service/impl/token/AuthTokenServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/token/AuthTokenServiceImpl.java
@@ -109,6 +109,7 @@ public class AuthTokenServiceImpl implements AuthTokenService {
                 .getPlatform()
                 .getId();
     }
+
     @Override
     public String issueAccessToken(long userId) {
         return tokenGenerator.generate(
@@ -117,7 +118,8 @@ public class AuthTokenServiceImpl implements AuthTokenService {
         );
     }
 
-    private String removePrefix(String value) {
+    @Override
+    public String removePrefix(String value) {
         return Optional.ofNullable(value)
                 .filter(t -> t.startsWith(tokenPrefix))
                 .map(t -> t.substring(tokenPrefix.length()))

--- a/src/main/java/org/recordy/server/keyword/controller/KeywordApi.java
+++ b/src/main/java/org/recordy/server/keyword/controller/KeywordApi.java
@@ -1,0 +1,25 @@
+package org.recordy.server.keyword.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.recordy.server.keyword.domain.Keyword;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "키워드 관련 API")
+public interface KeywordApi {
+
+    @Operation(
+            summary = "키워드 리스트 조회 API",
+            description = "사용중인 모든 키워드를 조회하는 API입니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공"
+                    )
+            }
+    )
+    ResponseEntity<List<Keyword>> getKeywords();
+}

--- a/src/main/java/org/recordy/server/keyword/controller/KeywordController.java
+++ b/src/main/java/org/recordy/server/keyword/controller/KeywordController.java
@@ -1,0 +1,27 @@
+package org.recordy.server.keyword.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.recordy.server.keyword.domain.Keyword;
+import org.recordy.server.keyword.service.KeywordService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/keywords")
+@RestController
+public class KeywordController {
+
+    private final KeywordService keywordService;
+
+    @GetMapping
+    public ResponseEntity<List<Keyword>> getKeywords() {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(keywordService.getAll());
+    }
+}

--- a/src/main/java/org/recordy/server/keyword/domain/Keyword.java
+++ b/src/main/java/org/recordy/server/keyword/domain/Keyword.java
@@ -21,16 +21,6 @@ public enum Keyword {
     트렌디한,
     ;
 
-    public static String encode() {
-        return Base64.getEncoder().encodeToString(
-                Arrays.stream(Keyword.values())
-                        .map(Enum::name)
-                        .reduce((a, b) -> a + "," + b)
-                        .orElseThrow()
-                        .getBytes(StandardCharsets.UTF_8)
-        );
-    }
-
     public static List<Keyword> decode(String utf8Bytes) {
         String[] keywords = new String(Base64.getDecoder().decode(utf8Bytes), StandardCharsets.UTF_8).split(",");
 

--- a/src/main/java/org/recordy/server/record_stat/controller/RecordStatApi.java
+++ b/src/main/java/org/recordy/server/record_stat/controller/RecordStatApi.java
@@ -51,7 +51,7 @@ public interface RecordStatApi {
                     )
             }
     )
-    public ResponseEntity<Void> bookmark(
+    public ResponseEntity<Boolean> bookmark(
             @UserId Long userId,
             @PathVariable Long recordId
     );

--- a/src/main/java/org/recordy/server/record_stat/controller/RecordStatApi.java
+++ b/src/main/java/org/recordy/server/record_stat/controller/RecordStatApi.java
@@ -21,8 +21,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface RecordStatApi {
 
     @Operation(
-            summary = "레코드 북마크 API",
-            description = "사용자가 특정 레코드를 북마크합니다.",
+            summary = "레코드 북마크 및 북마크 해제 API",
+            description = "사용자가 특정 레코드를 북마크하거나 북마크 해제합니다.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -52,42 +52,6 @@ public interface RecordStatApi {
             }
     )
     public ResponseEntity<Void> bookmark(
-            @UserId Long userId,
-            @PathVariable Long recordId
-    );
-
-    @Operation(
-            summary = "레코드 북마크 삭제 API",
-            description = "사용자가 특정 레코드의 북마크를 삭제합니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "204",
-                            description = "요청이 성공적으로 처리되었습니다.",
-                            content = @Content
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "Not Found - 존재하지 않는 사용자 또는 레코드입니다.",
-                            content = @Content(
-                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                    schema = @Schema(
-                                            implementation = ErrorMessage.class
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "Internal Server Error - 서버 내부 오류입니다.",
-                            content = @Content(
-                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                    schema = @Schema(
-                                            implementation = ErrorMessage.class
-                                    )
-                            )
-                    )
-            }
-    )
-    public ResponseEntity<Void> deleteBookmark(
             @UserId Long userId,
             @PathVariable Long recordId
     );

--- a/src/main/java/org/recordy/server/record_stat/controller/RecordStatController.java
+++ b/src/main/java/org/recordy/server/record_stat/controller/RecordStatController.java
@@ -10,7 +10,6 @@ import org.recordy.server.record_stat.service.RecordStatService;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/org/recordy/server/record_stat/controller/RecordStatController.java
+++ b/src/main/java/org/recordy/server/record_stat/controller/RecordStatController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/records")
 @RestController
 public class RecordStatController implements RecordStatApi{
+
     private final RecordStatService recordStatService;
 
     @Override
@@ -31,20 +32,9 @@ public class RecordStatController implements RecordStatApi{
             @PathVariable Long recordId
     ) {
         recordStatService.bookmark(userId, recordId);
+
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .build();
-    }
-
-    @Override
-    @DeleteMapping("/bookmark/{recordId}")
-    public ResponseEntity<Void> deleteBookmark(
-            @UserId Long userId,
-            @PathVariable Long recordId
-    ) {
-        recordStatService.deleteBookmark(userId, recordId);
-        return ResponseEntity
-                .status(HttpStatus.NO_CONTENT)
                 .build();
     }
 

--- a/src/main/java/org/recordy/server/record_stat/controller/RecordStatController.java
+++ b/src/main/java/org/recordy/server/record_stat/controller/RecordStatController.java
@@ -20,21 +20,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/records")
 @RestController
-public class RecordStatController implements RecordStatApi{
+public class RecordStatController implements RecordStatApi {
 
     private final RecordStatService recordStatService;
 
     @Override
     @PostMapping("/bookmark/{recordId}")
-    public ResponseEntity<Void> bookmark(
+    public ResponseEntity<Boolean> bookmark(
             @UserId Long userId,
             @PathVariable Long recordId
     ) {
-        recordStatService.bookmark(userId, recordId);
-
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .build();
+                .body(recordStatService.bookmark(userId, recordId));
     }
 
     @Override

--- a/src/main/java/org/recordy/server/record_stat/domain/usecase/Preference.java
+++ b/src/main/java/org/recordy/server/record_stat/domain/usecase/Preference.java
@@ -2,16 +2,15 @@ package org.recordy.server.record_stat.domain.usecase;
 
 import org.recordy.server.keyword.domain.Keyword;
 
-import java.security.Key;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.DoubleStream;
-import java.util.stream.Stream;
 
 public record Preference(
         long userId,
-        Map<Keyword, Long> preference
+        List<List<Object>> preference
 ) {
 
     public static Preference of(long userId, Map<Keyword, Long> preference) {
@@ -24,7 +23,7 @@ public record Preference(
                         (a, b) -> a,
                         LinkedHashMap::new));
 
-        return new Preference(userId, normalize(topPreference));
+        return new Preference(userId, transform(normalize(topPreference)));
     }
 
     private static Map<Keyword, Long> normalize(Map<Keyword, Long> preference) {
@@ -42,5 +41,16 @@ public record Preference(
         return preference.values().stream()
                 .mapToLong(Long::longValue)
                 .sum();
+    }
+
+    private static List<List<Object>> transform(Map<Keyword, Long> preference) {
+        return preference.entrySet().stream()
+                .map(entry -> {
+                    List<Object> list = new ArrayList<>();
+                    list.add(entry.getKey());
+                    list.add(entry.getValue());
+                    return list;
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/recordy/server/record_stat/service/RecordStatService.java
+++ b/src/main/java/org/recordy/server/record_stat/service/RecordStatService.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Slice;
 public interface RecordStatService {
 
     // command
-    void bookmark(long userId, long recordId);
+    boolean bookmark(long userId, long recordId);
 
     // query
     Preference getPreference(long userId);

--- a/src/main/java/org/recordy/server/record_stat/service/RecordStatService.java
+++ b/src/main/java/org/recordy/server/record_stat/service/RecordStatService.java
@@ -1,17 +1,15 @@
 package org.recordy.server.record_stat.service;
 
 import java.util.List;
-import org.recordy.server.record.controller.dto.response.RecordInfoWithBookmark;
+
 import org.recordy.server.record.domain.Record;
-import org.recordy.server.record_stat.domain.Bookmark;
 import org.recordy.server.record_stat.domain.usecase.Preference;
 import org.springframework.data.domain.Slice;
 
 public interface RecordStatService {
 
     // command
-    Bookmark bookmark(long userId, long recordId);
-    void deleteBookmark(long userId, long recordId);
+    void bookmark(long userId, long recordId);
 
     // query
     Preference getPreference(long userId);

--- a/src/main/java/org/recordy/server/record_stat/service/impl/RecordStatServiceImpl.java
+++ b/src/main/java/org/recordy/server/record_stat/service/impl/RecordStatServiceImpl.java
@@ -2,10 +2,9 @@ package org.recordy.server.record_stat.service.impl;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.recordy.server.common.message.ErrorMessage;
-import org.recordy.server.record.controller.dto.response.RecordInfo;
-import org.recordy.server.record.controller.dto.response.RecordInfoWithBookmark;
 import org.recordy.server.record.domain.Record;
 import org.recordy.server.record.exception.RecordException;
 import org.recordy.server.record.repository.RecordRepository;
@@ -29,21 +28,21 @@ public class RecordStatServiceImpl implements RecordStatService {
     private final BookmarkRepository bookmarkRepository;
 
     @Override
-    public Bookmark bookmark(long userId, long recordId) {
+    public void bookmark(long userId, long recordId) {
+        if (bookmarkRepository.existsByUserIdAndRecordId(userId, recordId)) {
+            bookmarkRepository.delete(userId, recordId);
+            return;
+        }
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
         Record record = recordRepository.findById(recordId)
                 .orElseThrow(() -> new RecordException(ErrorMessage.RECORD_NOT_FOUND));
 
-        return bookmarkRepository.save(Bookmark.builder()
+        bookmarkRepository.save(Bookmark.builder()
                 .user(user)
                 .record(record)
                 .build());
-    }
-
-    @Override
-    public void deleteBookmark(long userId, long recordId) {
-        bookmarkRepository.delete(userId, recordId);
     }
 
     @Override

--- a/src/main/java/org/recordy/server/record_stat/service/impl/RecordStatServiceImpl.java
+++ b/src/main/java/org/recordy/server/record_stat/service/impl/RecordStatServiceImpl.java
@@ -28,10 +28,10 @@ public class RecordStatServiceImpl implements RecordStatService {
     private final BookmarkRepository bookmarkRepository;
 
     @Override
-    public void bookmark(long userId, long recordId) {
+    public boolean bookmark(long userId, long recordId) {
         if (bookmarkRepository.existsByUserIdAndRecordId(userId, recordId)) {
             bookmarkRepository.delete(userId, recordId);
-            return;
+            return false;
         }
 
         User user = userRepository.findById(userId)
@@ -43,6 +43,8 @@ public class RecordStatServiceImpl implements RecordStatService {
                 .user(user)
                 .record(record)
                 .build());
+
+        return true;
     }
 
     @Override

--- a/src/main/java/org/recordy/server/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/recordy/server/subscribe/service/SubscribeService.java
@@ -9,7 +9,6 @@ public interface SubscribeService {
 
     // command
     void subscribe(SubscribeCreate subscribeCreate);
-    void unsubscribe(long subscribingUserId, long subscribedUserId);
 
     // query
     Slice<User> getSubscribedUsers(long subscribingUserId, long cursor, int size);

--- a/src/main/java/org/recordy/server/subscribe/service/SubscribeService.java
+++ b/src/main/java/org/recordy/server/subscribe/service/SubscribeService.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Slice;
 public interface SubscribeService {
 
     // command
-    void subscribe(SubscribeCreate subscribeCreate);
+    boolean subscribe(SubscribeCreate subscribeCreate);
 
     // query
     Slice<User> getSubscribedUsers(long subscribingUserId, long cursor, int size);

--- a/src/main/java/org/recordy/server/subscribe/service/impl/SubscribeServiceImpl.java
+++ b/src/main/java/org/recordy/server/subscribe/service/impl/SubscribeServiceImpl.java
@@ -24,6 +24,11 @@ public class SubscribeServiceImpl implements SubscribeService {
 
     @Override
     public void subscribe(SubscribeCreate subscribeCreate) {
+        if (subscribeRepository.existsBySubscribingUserIdAndSubscribedUserId(subscribeCreate.subscribingUserId(), subscribeCreate.subscribedUserId())) {
+            subscribeRepository.delete(subscribeCreate.subscribingUserId(), subscribeCreate.subscribedUserId());
+            return;
+        }
+
         User subscribingUser = userRepository.findById(subscribeCreate.subscribingUserId())
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
         User subscribedUser = userRepository.findById(subscribeCreate.subscribedUserId())
@@ -33,11 +38,6 @@ public class SubscribeServiceImpl implements SubscribeService {
                 .subscribingUser(subscribingUser)
                 .subscribedUser(subscribedUser)
                 .build());
-    }
-
-    @Override
-    public void unsubscribe(long subscribingUserId, long subscribedUserId) {
-        subscribeRepository.delete(subscribingUserId, subscribedUserId);
     }
 
     @Override

--- a/src/main/java/org/recordy/server/subscribe/service/impl/SubscribeServiceImpl.java
+++ b/src/main/java/org/recordy/server/subscribe/service/impl/SubscribeServiceImpl.java
@@ -23,10 +23,10 @@ public class SubscribeServiceImpl implements SubscribeService {
     private final UserRepository userRepository;
 
     @Override
-    public void subscribe(SubscribeCreate subscribeCreate) {
+    public boolean subscribe(SubscribeCreate subscribeCreate) {
         if (subscribeRepository.existsBySubscribingUserIdAndSubscribedUserId(subscribeCreate.subscribingUserId(), subscribeCreate.subscribedUserId())) {
             subscribeRepository.delete(subscribeCreate.subscribingUserId(), subscribeCreate.subscribedUserId());
-            return;
+            return false;
         }
 
         User subscribingUser = userRepository.findById(subscribeCreate.subscribingUserId())
@@ -38,6 +38,8 @@ public class SubscribeServiceImpl implements SubscribeService {
                 .subscribingUser(subscribingUser)
                 .subscribedUser(subscribedUser)
                 .build());
+
+        return true;
     }
 
     @Override

--- a/src/main/java/org/recordy/server/user/controller/UserApi.java
+++ b/src/main/java/org/recordy/server/user/controller/UserApi.java
@@ -19,8 +19,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "구독 관련 API")
 public interface UserApi {
     @Operation(
-            summary = "팔로우 API",
-            description = "특정 유저를 팔로우하는 API입니다. ",
+            summary = "팔로우 및 언팔로우 API",
+            description = "특정 유저를 팔로우하거나 언팔로우하는 API입니다. ",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -29,22 +29,6 @@ public interface UserApi {
             }
     )
     public ResponseEntity<Void> subscribe(
-            @UserId Long userId,
-            @PathVariable Long subscribedUserId
-    );
-
-    @Operation(
-            security = @SecurityRequirement(name = "Authorization"),
-            summary = "팔로우 취소 API",
-            description = "특정 유저에 대한 팔로우을 취소하는 API입니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "204",
-                            description = "요청이 성공했습니다."
-                    )
-            }
-    )
-    public ResponseEntity<Void> unsubscribe(
             @UserId Long userId,
             @PathVariable Long subscribedUserId
     );

--- a/src/main/java/org/recordy/server/user/controller/UserApi.java
+++ b/src/main/java/org/recordy/server/user/controller/UserApi.java
@@ -28,7 +28,7 @@ public interface UserApi {
                     )
             }
     )
-    public ResponseEntity<Void> subscribe(
+    public ResponseEntity<Boolean> subscribe(
             @UserId Long userId,
             @PathVariable Long subscribedUserId
     );

--- a/src/main/java/org/recordy/server/user/controller/UserController.java
+++ b/src/main/java/org/recordy/server/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package org.recordy.server.user.controller;
 
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.recordy.server.auth.security.UserId;
 import org.recordy.server.user.controller.dto.response.UserInfoWithFollowing;
@@ -11,7 +12,6 @@ import org.recordy.server.user.controller.dto.response.UserInfo;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,14 +28,13 @@ public class UserController implements UserApi {
 
     @Override
     @PostMapping("/follow/{followingId}")
-    public ResponseEntity<Void> subscribe(
+    public ResponseEntity<Boolean> subscribe(
             @UserId Long userId,
             @PathVariable Long followingId
     ) {
-        subscribeService.subscribe(new SubscribeCreate(userId, followingId));
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .build();
+                .body(subscribeService.subscribe(new SubscribeCreate(userId, followingId)));
     }
 
     @Override

--- a/src/main/java/org/recordy/server/user/controller/UserController.java
+++ b/src/main/java/org/recordy/server/user/controller/UserController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/users")
 @RestController
 public class UserController implements UserApi {
+
     private final SubscribeService subscribeService;
 
     @Override
@@ -34,18 +35,6 @@ public class UserController implements UserApi {
         subscribeService.subscribe(new SubscribeCreate(userId, followingId));
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .build();
-    }
-
-    @Override
-    @DeleteMapping("/unfollow/{followingId}")
-    public ResponseEntity<Void> unsubscribe(
-            @UserId Long userId,
-            @PathVariable Long followingId
-    ) {
-        subscribeService.unsubscribe(userId, followingId);
-        return ResponseEntity
-                .status(HttpStatus.NO_CONTENT)
                 .build();
     }
 

--- a/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
@@ -4,6 +4,7 @@ import feign.FeignException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.auth.domain.AuthPlatform;
+import org.recordy.server.auth.service.AuthTokenService;
 import org.recordy.server.user.domain.usecase.UserSignIn;
 import org.recordy.server.auth.service.AuthPlatformService;
 import org.recordy.server.mock.FakeContainer;
@@ -16,19 +17,25 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 public class AuthKakaoPlatformServiceImplTest {
 
     private AuthPlatformService kakaoPlatformService;
+    private AuthTokenService authTokenService;
 
     @BeforeEach
     void init() {
         kakaoPlatformService = new FakeContainer().authKakaoPlatformService;
+        authTokenService = new FakeContainer().authTokenService;
     }
 
     @Test
     void getPlatform을_통해_카카오_플랫폼을_통한_사용자_정보를_조회한다() {
         // given
         UserSignIn userSignIn = DomainFixture.createUserSignIn(DomainFixture.KAKAO_PLATFORM_TYPE);
+        UserSignIn realUserSignIn = new UserSignIn(
+                authTokenService.removePrefix(userSignIn.platformToken()),
+                DomainFixture.KAKAO_PLATFORM_TYPE
+        );
 
         // when
-        AuthPlatform platform = kakaoPlatformService.getPlatform(userSignIn);
+        AuthPlatform platform = kakaoPlatformService.getPlatform(realUserSignIn);
 
         // then
         assertAll(

--- a/src/test/java/org/recordy/server/keyword/domain/KeywordTest.java
+++ b/src/test/java/org/recordy/server/keyword/domain/KeywordTest.java
@@ -11,18 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class KeywordTest {
 
     @Test
-    void encode를_통해_모든_키워드를_utf8로_인코딩할_수_있다() {
-        // given, when
-        String encodedKeywords = Keyword.encode();
-        List<Keyword> keywords = Keyword.decode(encodedKeywords);
-
-        // then
-        assertAll(
-                () -> assertThat(keywords.size()).isEqualTo(Keyword.values().length)
-        );
-    }
-
-    @Test
     void decode를_통해_콤마로_연결된_채_인코딩된_문자열_utf8_코드를_해독하여_키워드_리스트로_디코딩할_수_있다() {
         // given
         String code = Base64.getEncoder().encodeToString("감각적인,강렬한".getBytes());

--- a/src/test/java/org/recordy/server/mock/auth/FakeKakaoFeignClient.java
+++ b/src/test/java/org/recordy/server/mock/auth/FakeKakaoFeignClient.java
@@ -13,6 +13,8 @@ public class FakeKakaoFeignClient implements KakaoFeignClient {
 
     @Override
     public KakaoPlatformInfo getKakaoAccessTokenInfo(String accessToken) {
+        System.out.println("accessToken = " + accessToken);
+
         if (!accessToken.equals(DomainFixture.PLATFORM_TOKEN) && !accessToken.equals("root")) {
             throw new FeignException.Unauthorized("Unauthorized",
                     Request.create(

--- a/src/test/java/org/recordy/server/mock/auth/FakeKakaoFeignClient.java
+++ b/src/test/java/org/recordy/server/mock/auth/FakeKakaoFeignClient.java
@@ -13,7 +13,6 @@ public class FakeKakaoFeignClient implements KakaoFeignClient {
 
     @Override
     public KakaoPlatformInfo getKakaoAccessTokenInfo(String accessToken) {
-        System.out.println("accessToken = " + accessToken);
 
         if (!accessToken.equals(DomainFixture.PLATFORM_TOKEN) && !accessToken.equals("root")) {
             throw new FeignException.Unauthorized("Unauthorized",

--- a/src/test/java/org/recordy/server/record_stat/service/RecordStatServiceTest.java
+++ b/src/test/java/org/recordy/server/record_stat/service/RecordStatServiceTest.java
@@ -11,18 +11,22 @@ import org.recordy.server.record.controller.dto.response.RecordInfoWithBookmark;
 import org.recordy.server.record.domain.Record;
 import org.recordy.server.record.repository.RecordRepository;
 import org.recordy.server.record_stat.domain.Bookmark;
+import org.recordy.server.record_stat.repository.BookmarkRepository;
 import org.recordy.server.user.domain.UserStatus;
 import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.util.DomainFixture;
 import org.springframework.data.domain.Slice;
 
 public class RecordStatServiceTest {
+
     private RecordStatService recordStatService;
+    private BookmarkRepository bookmarkRepository;
 
     @BeforeEach
     void init() {
         FakeContainer fakeContainer = new FakeContainer();
         recordStatService = fakeContainer.recordStatService;
+        bookmarkRepository = fakeContainer.bookmarkRepository;
         UserRepository userRepository = fakeContainer.userRepository;
         RecordRepository recordRepository = fakeContainer.recordRepository;
 
@@ -35,31 +39,26 @@ public class RecordStatServiceTest {
 
     @Test
     void bookmark을_통해_북마크를_생성할_수_있다() {
-        //given
-        //when
-        Bookmark bookmark = recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
+        // given, when
+        recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
 
         // then
         assertAll(
-                () -> assertThat(bookmark).isNotNull(),
-                () -> assertThat(bookmark.getUser().getId()).isEqualTo(DomainFixture.USER_ID),
-                () -> assertThat(bookmark.getRecord().getId()).isEqualTo(DomainFixture.RECORD_ID)
+                () -> assertThat(bookmarkRepository.existsByUserIdAndRecordId(DomainFixture.USER_ID, DomainFixture.RECORD_ID)).isTrue()
         );
     }
 
     @Test
-    void deleteBookmark를_통해_북마크를_삭제할_수_있다() {
+    void bookmark을_통해_북마크를_해제할_수_있다() {
         // given
-        recordStatService.bookmark(1, 1);
+        recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
 
         // when
-        recordStatService.deleteBookmark(1,1);
+        recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
 
         // then
-        Slice<Record> result = recordStatService.getBookmarkedRecords(1, 7, 10);
-
         assertAll(
-                () -> assertThat(result.getContent()).hasSize(0)
+                () -> assertThat(bookmarkRepository.existsByUserIdAndRecordId(DomainFixture.USER_ID, DomainFixture.RECORD_ID)).isFalse()
         );
     }
 

--- a/src/test/java/org/recordy/server/record_stat/service/RecordStatServiceTest.java
+++ b/src/test/java/org/recordy/server/record_stat/service/RecordStatServiceTest.java
@@ -38,26 +38,28 @@ public class RecordStatServiceTest {
     }
 
     @Test
-    void bookmark을_통해_북마크를_생성할_수_있다() {
+    void bookmark을_통해_북마크를_생성하고_true를_반환받을_수_있다() {
         // given, when
-        recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
+        boolean result = recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
 
         // then
         assertAll(
+                () -> assertThat(result).isTrue(),
                 () -> assertThat(bookmarkRepository.existsByUserIdAndRecordId(DomainFixture.USER_ID, DomainFixture.RECORD_ID)).isTrue()
         );
     }
 
     @Test
-    void bookmark을_통해_북마크를_해제할_수_있다() {
+    void bookmark을_통해_북마크를_해제하고_false를_반환받을_수_있다() {
         // given
         recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
 
         // when
-        recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
+        boolean result = recordStatService.bookmark(DomainFixture.USER_ID, DomainFixture.RECORD_ID);
 
         // then
         assertAll(
+                () -> assertThat(result).isFalse(),
                 () -> assertThat(bookmarkRepository.existsByUserIdAndRecordId(DomainFixture.USER_ID, DomainFixture.RECORD_ID)).isFalse()
         );
     }

--- a/src/test/java/org/recordy/server/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/org/recordy/server/subscribe/service/SubscribeServiceTest.java
@@ -48,14 +48,15 @@ class SubscribeServiceTest {
     }
 
     @Test
-    void unsubscribe를_통해_사용자_간_구독을_취소할_수_있다() {
+    void subscribe를_통해_사용자_간_구독을_해지할_수_있다() {
         // given
         userRepository.save(DomainFixture.createUser(1));
         userRepository.save(DomainFixture.createUser(2));
+
         subscribeService.subscribe(new SubscribeCreate(1, 2));
 
         // when
-        subscribeService.unsubscribe(1, 2);
+        subscribeService.subscribe(new SubscribeCreate(1, 2));
 
         // then
         assertAll(

--- a/src/test/java/org/recordy/server/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/org/recordy/server/subscribe/service/SubscribeServiceTest.java
@@ -6,7 +6,6 @@ import org.recordy.server.mock.FakeContainer;
 import org.recordy.server.subscribe.domain.Subscribe;
 import org.recordy.server.subscribe.domain.usecase.SubscribeCreate;
 import org.recordy.server.subscribe.repository.SubscribeRepository;
-import org.recordy.server.user.controller.dto.response.UserInfo;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.util.DomainFixture;
@@ -31,24 +30,25 @@ class SubscribeServiceTest {
     }
 
     @Test
-    void subscribe를_통해_사용자_간_구독할_수_있다() {
+    void subscribe를_통해_사용자_간_구독할_수_있고_결과로_true를_반환한다() {
         // given
         userRepository.save(DomainFixture.createUser(1));
         userRepository.save(DomainFixture.createUser(2));
 
         // when
-        subscribeService.subscribe(new SubscribeCreate(1, 2));
-        Slice<Subscribe> result = subscribeRepository.findAllBySubscribingUserId(1, 20, PageRequest.ofSize(3));
+        boolean result = subscribeService.subscribe(new SubscribeCreate(1, 2));
+        Slice<Subscribe> subscribes = subscribeRepository.findAllBySubscribingUserId(1, 20, PageRequest.ofSize(3));
 
         // then
         assertAll(
-                () -> assertThat(result.getContent().size()).isEqualTo(1),
-                () -> assertThat(result.getContent().get(0).getSubscribedUser().getId()).isEqualTo(2)
+                () -> assertThat(result).isTrue(),
+                () -> assertThat(subscribes.getContent().size()).isEqualTo(1),
+                () -> assertThat(subscribes.getContent().get(0).getSubscribedUser().getId()).isEqualTo(2)
         );
     }
 
     @Test
-    void subscribe를_통해_사용자_간_구독을_해지할_수_있다() {
+    void subscribe를_통해_사용자_간_구독을_해지할_수_있고_결과로_false를_반환한다() {
         // given
         userRepository.save(DomainFixture.createUser(1));
         userRepository.save(DomainFixture.createUser(2));
@@ -56,10 +56,11 @@ class SubscribeServiceTest {
         subscribeService.subscribe(new SubscribeCreate(1, 2));
 
         // when
-        subscribeService.subscribe(new SubscribeCreate(1, 2));
+        boolean result = subscribeService.subscribe(new SubscribeCreate(1, 2));
 
         // then
         assertAll(
+                () -> assertThat(result).isFalse(),
                 () -> assertThat(subscribeRepository.existsBySubscribingUserIdAndSubscribedUserId(1, 2)).isFalse()
         );
     }

--- a/src/test/java/org/recordy/server/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/org/recordy/server/user/controller/UserAuthControllerTest.java
@@ -10,6 +10,7 @@ import org.recordy.server.user.controller.dto.request.UserSignInRequest;
 import org.recordy.server.user.controller.dto.response.UserReissueTokenResponse;
 import org.recordy.server.user.controller.dto.response.UserSignInResponse;
 import org.recordy.server.user.domain.User;
+import org.recordy.server.user.domain.usecase.UserSignIn;
 import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.user.service.UserService;
@@ -39,11 +40,11 @@ public class UserAuthControllerTest {
     @Test
     void signIn을_통해_사용자는_카카오_플랫폼_토큰을_통해_가입_이후_토큰을_반환받을_수_있다() {
         // given
-        String platformToken = "platform_token";
-        UserSignInRequest request = new UserSignInRequest(AuthPlatform.Type.KAKAO);
+        UserSignIn userSignIn = DomainFixture.createUserSignIn(AuthPlatform.Type.KAKAO);
+        UserSignInRequest userSignInRequest = new UserSignInRequest(AuthPlatform.Type.KAKAO);
 
         // when
-        ResponseEntity<UserSignInResponse> result = userAuthController.signIn(platformToken, request);
+        ResponseEntity<UserSignInResponse> result = userAuthController.signIn(userSignIn.platformToken(), userSignInRequest);
 
         // then
         assertAll(
@@ -57,11 +58,11 @@ public class UserAuthControllerTest {
     @Test
     void signIn을_통해_사용자는_애플_플랫폼_토큰을_통해_가입_이후_토큰을_반환받을_수_있다() {
         // given
-        String platformToken = "platform_token";
-        UserSignInRequest request = new UserSignInRequest(AuthPlatform.Type.APPLE);
+        UserSignIn userSignIn = DomainFixture.createUserSignIn(AuthPlatform.Type.APPLE);
+        UserSignInRequest userSignInRequest = new UserSignInRequest(AuthPlatform.Type.APPLE);
 
         // when
-        ResponseEntity<UserSignInResponse> result = userAuthController.signIn(platformToken, request);
+        ResponseEntity<UserSignInResponse> result = userAuthController.signIn(userSignIn.platformToken(), userSignInRequest);
 
         // then
         assertAll(

--- a/src/test/java/org/recordy/server/util/DomainFixture.java
+++ b/src/test/java/org/recordy/server/util/DomainFixture.java
@@ -107,7 +107,7 @@ public final class DomainFixture {
 
     public static UserSignIn createUserSignIn(AuthPlatform.Type platformType) {
         return new UserSignIn(
-                PLATFORM_TOKEN,
+                TOKEN_PREFIX + PLATFORM_TOKEN,
                 platformType
         );
     }


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: #79

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- follow 등록/삭제 통일 및 true/false 반환
- bookmark 등록/삭제 통일 true/false 반환
- signIn에서 `Bearer` prefix 받는다고 가정하고 수정
- Preference의 반환 타입을 Map<String, Long>에서 List<List<Object>>로 변경
- KeywordController, KeywordApi 생성 및 모든 키워드 리스트 반환하는 API 작성

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
