### PR TITLE
[refactor] signIn시 userId도 함께 전달하도록 수정

### DIFF
--- a/src/main/java/org/recordy/server/auth/domain/Auth.java
+++ b/src/main/java/org/recordy/server/auth/domain/Auth.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 public class Auth {
 
+    private Long userId;
     private AuthPlatform platform;
     private AuthToken token;
     private boolean isSignedUp;

--- a/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
+++ b/src/main/java/org/recordy/server/auth/domain/AuthEntity.java
@@ -16,6 +16,7 @@ public class AuthEntity {
 
     @Id
     private String platformId;
+    private Long userId;
     private String platformType;
     private String accessToken;
     @Indexed
@@ -25,6 +26,7 @@ public class AuthEntity {
     public static AuthEntity from(Auth auth) {
         return new AuthEntity(
                 auth.getPlatform().getId(),
+                auth.getUserId(),
                 auth.getPlatform().getType().name(),
                 auth.getToken().getAccessToken(),
                 auth.getToken().getRefreshToken(),
@@ -34,6 +36,7 @@ public class AuthEntity {
 
     public Auth toDomain() {
         return new Auth(
+                userId,
                 new AuthPlatform(platformId, AuthPlatform.Type.valueOf(platformType)),
                 new AuthToken(accessToken, refreshToken),
                 isSignedUp

--- a/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/recordy/server/auth/service/impl/AuthServiceImpl.java
@@ -31,6 +31,7 @@ public class AuthServiceImpl implements AuthService {
         AuthToken token = authTokenService.issueToken(user.getId());
 
         return authRepository.save(Auth.builder()
+                .userId(user.getId())
                 .platform(platform)
                 .token(token)
                 .isSignedUp(user.getStatus().equals(ACTIVE))

--- a/src/main/java/org/recordy/server/user/controller/dto/response/UserSignInResponse.java
+++ b/src/main/java/org/recordy/server/user/controller/dto/response/UserSignInResponse.java
@@ -3,6 +3,7 @@ package org.recordy.server.user.controller.dto.response;
 import org.recordy.server.auth.domain.Auth;
 
 public record UserSignInResponse(
+        Long userId,
         String accessToken,
         String refreshToken,
         boolean isSignedUp
@@ -10,6 +11,7 @@ public record UserSignInResponse(
 
     public static UserSignInResponse from(Auth auth) {
         return new UserSignInResponse(
+                auth.getUserId(),
                 auth.getToken().getAccessToken(),
                 auth.getToken().getRefreshToken(),
                 auth.isSignedUp()

--- a/src/test/java/org/recordy/server/auth/service/AuthTokenServiceTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthTokenServiceTest.java
@@ -191,7 +191,7 @@ public class AuthTokenServiceTest {
         //given
         AuthPlatform authPlatform = DomainFixture.createAuthPlatform();
         AuthToken authToken = authTokenService.issueToken(DomainFixture.USER_ID);
-        authRepository.save(new Auth(authPlatform, authToken, true));
+        authRepository.save(new Auth(DomainFixture.USER_ID, authPlatform, authToken, true));
 
         //when
         String refreshToken = "Bearer " + authToken.getRefreshToken();

--- a/src/test/java/org/recordy/server/util/DomainFixture.java
+++ b/src/test/java/org/recordy/server/util/DomainFixture.java
@@ -89,6 +89,7 @@ public final class DomainFixture {
 
     public static Auth createAuth(boolean isSignedUp) {
         return new Auth(
+                USER_ID,
                 createAuthPlatform(),
                 createAuthToken(),
                 isSignedUp
@@ -98,6 +99,7 @@ public final class DomainFixture {
     public static AuthEntity createAuthEntity(boolean isSignedUp) {
         return new AuthEntity(
                 PLATFORM_ID,
+                USER_ID,
                 KAKAO_PLATFORM_TYPE.name(),
                 ACCESS_TOKEN,
                 REFRESH_TOKEN,


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: #89 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 클라의 요청으로 signIn에 userId를 함께 반환하도록 로직을 변경했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 지금 Auth와 AuthEntitiy에 userId를 포함하는 식으로 로직을 변경했는데, 이게 최선의 방법인지는 조금 의문이 듭니다. 관련해서 조언이 있다면 마구마구 해주세용
