### PR TITLE
[feat] 기록 객체 저장시 객체 url S3 -> cloudfront

### DIFF
--- a/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
@@ -42,13 +42,31 @@ public class RecordServiceImpl implements RecordService {
         User user = userRepository.findById(recordCreate.uploaderId())
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
 
+        String s3VideoUrl = recordCreate.fileUrl().videoUrl();
+        String s3ThumbnailUrl = recordCreate.fileUrl().thumbnailUrl();
+
+        String cloudFrontVideoUrl = convertToCloudFrontUrl(s3VideoUrl);
+        String cloudFrontThumbnailUrl = convertToCloudFrontUrl(s3ThumbnailUrl);
+
+        FileUrl fileUrl = FileUrl.of(cloudFrontVideoUrl, cloudFrontThumbnailUrl);
+
         return recordRepository.save(Record.builder()
-                .fileUrl(recordCreate.fileUrl())
+                .fileUrl(fileUrl)
                 .location(recordCreate.location())
                 .content(recordCreate.content())
                 .uploader(user)
                 .keywords(recordCreate.keywords())
                 .build());
+    }
+
+    private String convertToCloudFrontUrl(String s3Url) {
+        // CloudFront 배포 도메인 이름
+        String cloudFrontDomain = "d2p19guzt9trnp.cloudfront.net";
+
+        // S3 버킷 도메인 부분을 CloudFront 도메인으로 대체
+        String cloudFrontUrl = s3Url.replace("recordy-bucket.s3.ap-northeast-2.amazonaws.com", cloudFrontDomain);
+
+        return cloudFrontUrl;
     }
 
     @Override

--- a/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
@@ -42,13 +42,7 @@ public class RecordServiceImpl implements RecordService {
         User user = userRepository.findById(recordCreate.uploaderId())
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
 
-        String s3VideoUrl = recordCreate.fileUrl().videoUrl();
-        String s3ThumbnailUrl = recordCreate.fileUrl().thumbnailUrl();
-
-        String cloudFrontVideoUrl = convertToCloudFrontUrl(s3VideoUrl);
-        String cloudFrontThumbnailUrl = convertToCloudFrontUrl(s3ThumbnailUrl);
-
-        FileUrl fileUrl = FileUrl.of(cloudFrontVideoUrl, cloudFrontThumbnailUrl);
+        FileUrl fileUrl = convertToCloudFrontUrl(recordCreate.fileUrl());
 
         return recordRepository.save(Record.builder()
                 .fileUrl(fileUrl)
@@ -59,15 +53,17 @@ public class RecordServiceImpl implements RecordService {
                 .build());
     }
 
-    private String convertToCloudFrontUrl(String s3Url) {
-        // CloudFront 배포 도메인 이름
+
+    private FileUrl convertToCloudFrontUrl(FileUrl fileUrl) {
         String cloudFrontDomain = "d2p19guzt9trnp.cloudfront.net";
+        String s3Domain = "recordy-bucket.s3.ap-northeast-2.amazonaws.com";
 
-        // S3 버킷 도메인 부분을 CloudFront 도메인으로 대체
-        String cloudFrontUrl = s3Url.replace("recordy-bucket.s3.ap-northeast-2.amazonaws.com", cloudFrontDomain);
+        String cloudFrontVideoUrl = fileUrl.videoUrl().replace(s3Domain, cloudFrontDomain);
+        String cloudFrontThumbnailUrl = fileUrl.thumbnailUrl().replace(s3Domain, cloudFrontDomain);
 
-        return cloudFrontUrl;
+        return FileUrl.of(cloudFrontVideoUrl, cloudFrontThumbnailUrl);
     }
+
 
     @Override
     public void delete(long userId, long recordId) {

--- a/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
@@ -21,6 +21,7 @@ import org.recordy.server.view.repository.ViewRepository;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -36,6 +37,12 @@ public class RecordServiceImpl implements RecordService {
     private final ViewRepository viewRepository;
     private final BookmarkRepository bookmarkRepository;
     private final UserRepository userRepository;
+
+    @Value("${aws-property.cloudfront-domain-name}")
+    private String cloudFrontDomain;
+
+    @Value("${aws-property.s3-domain}")
+    private String s3Domain;
 
     @Override
     public Record create(RecordCreate recordCreate) {
@@ -55,9 +62,6 @@ public class RecordServiceImpl implements RecordService {
 
 
     private FileUrl convertToCloudFrontUrl(FileUrl fileUrl) {
-        String cloudFrontDomain = "d2p19guzt9trnp.cloudfront.net";
-        String s3Domain = "recordy-bucket.s3.ap-northeast-2.amazonaws.com";
-
         String cloudFrontVideoUrl = fileUrl.videoUrl().replace(s3Domain, cloudFrontDomain);
         String cloudFrontThumbnailUrl = fileUrl.thumbnailUrl().replace(s3Domain, cloudFrontDomain);
 


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: #100 
- 백번째는 제것입니다.

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
record를 GET해올 시 비용이 많이 드는 문제를 cloudfront로 해결하였습니다 !
put은 동일하게 presignedUrl을 사용합니다.

put -> presignedUrl
get -> cloudfront

사용자 정의 백엔드 오리진(예: HTTP 서버, API 게이트웨이)과 상호작용할 때 : PUT, POST, PATCH, DELETE

 S3 버킷을 오리진으로 사용할 때 : 주로 사용 X

[s3 객체 url]( https://recordy-bucket.s3.ap-northeast-2.amazonaws.com/videos/70116dd4-4ace-4c60-a257-94a6f1a39ecb.mp4) -> [cloudfront]( https://d2p19guzt9trnp.cloudfront.net/videos/70116dd4-4ace-4c60-a257-94a6f1a39ecb.mp4)
이 점을 이용해서 createRecord시 `convertToCloudFrontUrl`를 활용해서 replace를 이용해줄 수 있도록 하였습니다 ~!

```java
private String convertToCloudFrontUrl(String s3Url) {
        // CloudFront 배포 도메인 이름
        String cloudFrontDomain = "d2p19guzt9trnp.cloudfront.net";

        // S3 버킷 도메인 부분을 CloudFront 도메인으로 대체
        String cloudFrontUrl = s3Url.replace("recordy-bucket.s3.ap-northeast-2.amazonaws.com", cloudFrontDomain);

        return cloudFrontUrl;
    }
```

<img width="1049" alt="스크린샷 2024-08-05 오전 1 15 23" src="https://github.com/user-attachments/assets/1887215d-2474-4705-91cc-bb0736d5c9d8">

<img width="832" alt="스크린샷 2024-08-05 오전 1 15 30" src="https://github.com/user-attachments/assets/0d2d1c28-a7bd-4357-9576-499eeaeac487">

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
