### PR TITLE
[test] s3 비용 테스트 get api

### DIFF
--- a/src/main/java/org/recordy/server/record/controller/RecordController.java
+++ b/src/main/java/org/recordy/server/record/controller/RecordController.java
@@ -39,6 +39,12 @@ public class RecordController implements RecordApi {
                 .body(s3Service.generatePresignedUrl());
     }
 
+    @GetMapping("/all")
+    public ResponseEntity<List<Record>> getAllRecords() {
+        List<Record> records = recordService.getAllRecords();
+        return ResponseEntity.ok(records);
+    }
+
     @Override
     @PostMapping
     public ResponseEntity<Void> createRecord(

--- a/src/main/java/org/recordy/server/record/repository/RecordRepository.java
+++ b/src/main/java/org/recordy/server/record/repository/RecordRepository.java
@@ -26,4 +26,5 @@ public interface RecordRepository {
     long countAllByUserId(long userId);
     Optional<Long> findMaxId();
     Long count();
+    List<Record> findAll();
 }

--- a/src/main/java/org/recordy/server/record/repository/impl/RecordRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/record/repository/impl/RecordRepositoryImpl.java
@@ -39,6 +39,15 @@ public class RecordRepositoryImpl implements RecordRepository {
                 .ifPresent(recordJpaRepository::delete);
     }
 
+
+
+    @Override
+    public List<Record> findAll() {
+        return recordJpaRepository.findAll().stream()
+                .map(RecordEntity::toDomain)
+                .toList();
+    }
+
     @Transactional
     @Override
     public void deleteByUserId(long userId) {

--- a/src/main/java/org/recordy/server/record/service/RecordService.java
+++ b/src/main/java/org/recordy/server/record/service/RecordService.java
@@ -20,4 +20,5 @@ public interface RecordService {
     Slice<Record> getRecentRecordsByUser(long userId, Long cursorId, int size);
     Slice<Record> getSubscribingRecords(long userId, Long cursorId, int size);
     List<Record> getTotalRecords(int size);
+    List<Record> getAllRecords();
 }

--- a/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
@@ -60,6 +60,10 @@ public class RecordServiceImpl implements RecordService {
                 .build());
     }
 
+    @Override
+    public List<Record> getAllRecords() {
+        return recordRepository.findAll();
+    }
 
     private FileUrl convertToCloudFrontUrl(FileUrl fileUrl) {
         String cloudFrontVideoUrl = fileUrl.videoUrl().replace(s3Domain, cloudFrontDomain);

--- a/src/test/java/org/recordy/server/cloudfront/CloudfrontVsS3ConcurrentTest.java
+++ b/src/test/java/org/recordy/server/cloudfront/CloudfrontVsS3ConcurrentTest.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class CloudfrontVsS3Test {
+public class CloudfrontVsS3ConcurrentTest {
 
     private RestTemplate restTemplate;
     private static final String S3_DOMAIN = "recordy-bucket.s3.ap-northeast-2.amazonaws.com";
@@ -31,12 +31,11 @@ public class CloudfrontVsS3Test {
             "https://{domain}/thumbnails/07036dcf-c580-4493-93ad-01a4bf4a6395.jpeg"
     };
 
-    int numberOfConcurrentUsers = 3;
+    int numberOfConcurrentUsers = 10;
     ExecutorService executorService;
 
     AtomicLong latency;
     AtomicInteger cacheHits;
-
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/org/recordy/server/cloudfront/CloudfrontVsS3SequentialTest.java
+++ b/src/test/java/org/recordy/server/cloudfront/CloudfrontVsS3SequentialTest.java
@@ -1,0 +1,86 @@
+package org.recordy.server.cloudfront;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class CloudfrontVsS3SequentialTest {
+
+    private RestTemplate restTemplate;
+    private static final String S3_DOMAIN = "recordy-bucket.s3.ap-northeast-2.amazonaws.com";
+    private static final String CLOUDFRONT_DOMAIN = "d2p19guzt9trnp.cloudfront.net";
+    private String[] urls = {
+            "https://{domain}/thumbnails/009bdfac-d02b-4f85-bf6d-c08b36e36ea3.jpeg",
+            "https://{domain}/thumbnails/0119d0e3-75e7-4e1b-8598-36cf65db89bd.jpeg",
+            "https://{domain}/thumbnails/02075a21-3ad2-42d1-8bbd-f900c561170c.jpg",
+            "https://{domain}/thumbnails/0272c691-d0e8-4ec5-b616-6c912e049c05.jpeg",
+            "https://{domain}/thumbnails/036cb125-97de-4a04-b6e1-c00ab8e8ed73.jpeg",
+            "https://{domain}/thumbnails/03b95e00-6c25-4cb8-9a2d-1746282021cb.jpeg",
+            "https://{domain}/thumbnails/03f1d3cf-a100-4e33-b3f1-10670508aad0.jpeg",
+            "https://{domain}/thumbnails/04a9c879-9eff-4bcb-a0b7-8cbf2d2f5fed.jpeg",
+            "https://{domain}/thumbnails/04aa62ce-efc9-4b53-ac55-c02c62f7993a.jpeg",
+            "https://{domain}/thumbnails/07036dcf-c580-4493-93ad-01a4bf4a6395.jpeg"
+    };
+
+    int numberOfSequentialUsers = 100;
+
+    AtomicLong latency;
+    AtomicInteger cacheHits;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+
+        latency = new AtomicLong(0);
+        cacheHits = new AtomicInteger(0);
+    }
+
+    @Test
+    void S3_객체에_대해_정해진_수만큼_순차적으로_요청한다() throws Exception {
+        executeSequentially(S3_DOMAIN);
+    }
+
+    @Test
+    void Cloudfront_객체에_대해_정해진_수만큼_순차적으로_요청한다() throws Exception {
+        executeSequentially(CLOUDFRONT_DOMAIN);
+    }
+
+    private void executeSequentially(String domain) throws Exception {
+        for (int i = 0; i < numberOfSequentialUsers; i++) {
+            long start = System.currentTimeMillis();
+            sendHttpRequest(domain);
+            long end = System.currentTimeMillis();
+
+            latency.addAndGet(end - start);
+        }
+
+        printResult();
+    }
+
+    public void sendHttpRequest(String domain) {
+        for (String url : urls) {
+            String replacedUrl = url.replace("{domain}", domain);
+
+            ResponseEntity<String> response = restTemplate.exchange(replacedUrl, HttpMethod.GET, null, String.class);
+            incrementCacheHits(response);
+        }
+    }
+
+    private void incrementCacheHits(ResponseEntity<String> response) {
+        String cacheHeader = response.getHeaders().getFirst("X-Cache");
+
+        if (Objects.nonNull(cacheHeader) && cacheHeader.startsWith("Hit from cloudfront"))
+            cacheHits.incrementAndGet();
+    }
+
+    private void printResult() {
+        System.out.println("latency = " + latency.get() + "ms");
+        System.out.println("cacheHits = " + cacheHits);
+    }
+}

--- a/src/test/java/org/recordy/server/cloudfront/CloudfrontVsS3Test.java
+++ b/src/test/java/org/recordy/server/cloudfront/CloudfrontVsS3Test.java
@@ -1,0 +1,94 @@
+package org.recordy.server.cloudfront;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class CloudfrontVsS3Test {
+
+    private RestTemplate restTemplate;
+    private static final String S3_DOMAIN = "recordy-bucket.s3.ap-northeast-2.amazonaws.com";
+    private static final String CLOUDFRONT_DOMAIN = "d2p19guzt9trnp.cloudfront.net";
+    private String[] urls = {
+            "https://{domain}/thumbnails/009bdfac-d02b-4f85-bf6d-c08b36e36ea3.jpeg",
+            "https://{domain}/thumbnails/0119d0e3-75e7-4e1b-8598-36cf65db89bd.jpeg",
+            "https://{domain}/thumbnails/02075a21-3ad2-42d1-8bbd-f900c561170c.jpg",
+            "https://{domain}/thumbnails/0272c691-d0e8-4ec5-b616-6c912e049c05.jpeg",
+            "https://{domain}/thumbnails/036cb125-97de-4a04-b6e1-c00ab8e8ed73.jpeg",
+            "https://{domain}/thumbnails/03b95e00-6c25-4cb8-9a2d-1746282021cb.jpeg",
+            "https://{domain}/thumbnails/03f1d3cf-a100-4e33-b3f1-10670508aad0.jpeg",
+            "https://{domain}/thumbnails/04a9c879-9eff-4bcb-a0b7-8cbf2d2f5fed.jpeg",
+            "https://{domain}/thumbnails/04aa62ce-efc9-4b53-ac55-c02c62f7993a.jpeg",
+            "https://{domain}/thumbnails/07036dcf-c580-4493-93ad-01a4bf4a6395.jpeg"
+    };
+
+    int numberOfConcurrentUsers = 3;
+    ExecutorService executorService;
+
+    AtomicLong latency;
+    AtomicInteger cacheHits;
+
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+        executorService = Executors.newFixedThreadPool(numberOfConcurrentUsers);
+
+        latency = new AtomicLong(0);
+        cacheHits = new AtomicInteger(0);
+    }
+
+    @Test
+    void S3_객체에_대해_정해진_수만큼_동시다발적으로_요청한다() throws Exception {
+        executeConcurrently(S3_DOMAIN);
+    }
+
+    @Test
+    void Cloudfront_객체에_대해_정해진_수만큼_동시다발적으로_요청한다() throws Exception {
+        executeConcurrently(CLOUDFRONT_DOMAIN);
+    }
+
+    private void executeConcurrently(String domain) throws Exception {
+        for (int i = 0; i < numberOfConcurrentUsers; i++)
+            executorService.execute(() -> sendHttpRequest(domain));
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        printResult();
+    }
+
+    private void sendHttpRequest(String domain) {
+        for (String url : urls) {
+            String replacedUrl = url.replace("{domain}", domain);
+
+            long start = System.currentTimeMillis();
+            ResponseEntity<String> response = restTemplate.exchange(replacedUrl, HttpMethod.GET, null, String.class);
+            long end = System.currentTimeMillis();
+
+            latency.addAndGet(end - start);
+            incrementCacheHits(response);
+        }
+    }
+
+    private void incrementCacheHits(ResponseEntity<String> response) {
+        String cacheHeader = response.getHeaders().getFirst("X-Cache");
+
+        if (Objects.nonNull(cacheHeader) && cacheHeader.startsWith("Hit from cloudfront"))
+            cacheHits.incrementAndGet();
+    }
+
+    private void printResult() {
+        System.out.println("latency = " + latency.get() + "ms");
+        System.out.println("cacheHits = " + cacheHits);
+    }
+}

--- a/src/test/java/org/recordy/server/mock/record/FakeRecordRepository.java
+++ b/src/test/java/org/recordy/server/mock/record/FakeRecordRepository.java
@@ -65,6 +65,11 @@ public class FakeRecordRepository implements RecordRepository {
     }
 
     @Override
+    public List<Record> findAll() {
+        return new ArrayList<>(records.values());
+    }
+
+    @Override
     public Slice<Record> findAllOrderByPopularity(Pageable pageable) {
         return null;
     }

--- a/src/test/java/org/recordy/server/record/controller/RecordControllerTest.java
+++ b/src/test/java/org/recordy/server/record/controller/RecordControllerTest.java
@@ -1,0 +1,26 @@
+package org.recordy.server.record.controller;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class RecordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RepeatedTest(1)
+    void testGetAllRecords() throws Exception {
+        mockMvc.perform(get("/api/v1/records/all"))
+                .andExpect(status().isOk());
+    }
+
+}


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: #105

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

- S3 버킷 객체 / cloudfront 가격비교를 위한 임시 get api 생성 후 DB에 있는 모든 객체 (10개)를 호출해올 수 있도록 했습니다.
- RepeatTest를 통해서 10개 데이터를 n번 호출하는 방식으로 for문을 사용하지 않고 했습니다. 
(작동되는지 확인을 위해 1을 넣었으며, aws요금이 변동된 것을 확인했습니다.)
-> 여기서 for문으로 천개 데이터를 넣고 1번 호출 vs 10개 데이터 넣고 100번 호출 고민했는데 후자로 진행했습니다.
(추후에 수빈이에게 물어보니 후자로 진행 동의했습니다 ~)
- 버킷객체로 테스트 돌려보고, DB에서 cloudfront로 url수정해서 다시 테스트 돌림됩니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

```sql
UPDATE records
SET thumbnail_url = REPLACE(thumbnail_url, 
    'https://recordy-bucket.s3.ap-northeast-2.amazonaws.com/', 
    'https://d2p19guzt9trnp.cloudfront.net/')
WHERE thumbnail_url LIKE 'https://recordy-bucket.s3.ap-northeast-2.amazonaws.com/%';

```
