### PR TITLE
S3Service 리팩토링 및 Repository 단일 객체 조회시 Optional 타입 아닌 일반 타입 제공하도록 수정

### DIFF
--- a/src/main/java/org/recordy/server/bookmark/service/impl/BookmarkServiceImpl.java
+++ b/src/main/java/org/recordy/server/bookmark/service/impl/BookmarkServiceImpl.java
@@ -11,7 +11,6 @@ import org.recordy.server.record.domain.Record;
 import org.recordy.server.record.exception.RecordException;
 import org.recordy.server.record.repository.RecordRepository;
 import org.recordy.server.user.domain.User;
-import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -35,8 +34,7 @@ public class BookmarkServiceImpl implements BookmarkService {
             return false;
         }
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User user = userRepository.findById(userId);
         Record record = recordRepository.findById(recordId)
                 .orElseThrow(() -> new RecordException(ErrorMessage.RECORD_NOT_FOUND));
 

--- a/src/main/java/org/recordy/server/bookmark/service/impl/BookmarkServiceImpl.java
+++ b/src/main/java/org/recordy/server/bookmark/service/impl/BookmarkServiceImpl.java
@@ -35,8 +35,7 @@ public class BookmarkServiceImpl implements BookmarkService {
         }
 
         User user = userRepository.findById(userId);
-        Record record = recordRepository.findById(recordId)
-                .orElseThrow(() -> new RecordException(ErrorMessage.RECORD_NOT_FOUND));
+        Record record = recordRepository.findById(recordId);
 
         bookmarkRepository.save(Bookmark.builder()
                 .user(user)

--- a/src/main/java/org/recordy/server/record/repository/RecordRepository.java
+++ b/src/main/java/org/recordy/server/record/repository/RecordRepository.java
@@ -24,6 +24,6 @@ public interface RecordRepository {
     Slice<Record> findAllByUserIdOrderByIdDesc(long userId, Long cursor, Pageable pageable);
     Slice<Record> findAllBySubscribingUserIdOrderByIdDesc(long userId, Long cursor, Pageable pageable);
     long countAllByUserId(long userId);
-    Optional<Long> findMaxId();
+    Long findMaxId();
     Long count();
 }

--- a/src/main/java/org/recordy/server/record/repository/RecordRepository.java
+++ b/src/main/java/org/recordy/server/record/repository/RecordRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface RecordRepository {
 
@@ -16,7 +15,7 @@ public interface RecordRepository {
     void deleteByUserId(long userId);
 
     // query
-    Optional<Record> findById(long id);
+    Record findById(long id);
     Slice<Record> findAllOrderByPopularity(Pageable pageable);
     Slice<Record> findAllByKeywordsOrderByPopularity(List<Keyword> keywords, Pageable pageable);
     Slice<Record> findAllByIdAfterOrderByIdDesc(Long cursor, Pageable pageable);

--- a/src/main/java/org/recordy/server/record/repository/impl/RecordQueryDslRepository.java
+++ b/src/main/java/org/recordy/server/record/repository/impl/RecordQueryDslRepository.java
@@ -28,7 +28,6 @@ public class RecordQueryDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-
     public Slice<RecordEntity> findAllOrderByPopularity(Pageable pageable) {
         LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
 
@@ -46,7 +45,7 @@ public class RecordQueryDslRepository {
     }
 
 
-public Slice<RecordEntity> findAllByKeywordsOrderByPopularity(List<KeywordEntity> keywords, Pageable pageable) {
+    public Slice<RecordEntity> findAllByKeywordsOrderByPopularity(List<KeywordEntity> keywords, Pageable pageable) {
         LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
 
         List<RecordEntity> recordEntities = jpaQueryFactory
@@ -141,5 +140,4 @@ public Slice<RecordEntity> findAllByKeywordsOrderByPopularity(List<KeywordEntity
                         .fetchOne()
         );
     }
-
 }

--- a/src/main/java/org/recordy/server/record/repository/impl/RecordQueryDslRepository.java
+++ b/src/main/java/org/recordy/server/record/repository/impl/RecordQueryDslRepository.java
@@ -95,7 +95,7 @@ public class RecordQueryDslRepository {
 
     public Slice<RecordEntity> findAllByUserIdOrderByIdDesc(long userId, Long cursor, Pageable pageable) {
         List<RecordEntity> recordEntities = jpaQueryFactory
-                .selectFrom((recordEntity))
+                .selectFrom(recordEntity)
                 .join(recordEntity.user, userEntity)
                 .where(
                         QueryDslUtils.ltCursorId(cursor, recordEntity.id),

--- a/src/main/java/org/recordy/server/record/repository/impl/RecordRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/record/repository/impl/RecordRepositoryImpl.java
@@ -3,11 +3,13 @@ package org.recordy.server.record.repository.impl;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
+import org.recordy.server.common.message.ErrorMessage;
 import org.recordy.server.keyword.domain.Keyword;
 import org.recordy.server.keyword.domain.KeywordEntity;
 import org.recordy.server.keyword.repository.impl.KeywordJpaRepository;
 import org.recordy.server.record.domain.Record;
 import org.recordy.server.record.domain.RecordEntity;
+import org.recordy.server.record.exception.RecordException;
 import org.recordy.server.record.repository.RecordRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -46,9 +48,10 @@ public class RecordRepositoryImpl implements RecordRepository {
     }
 
     @Override
-    public Optional<Record> findById(long recordId) {
+    public Record findById(long recordId) {
         return recordJpaRepository.findById(recordId)
-                .map(RecordEntity::toDomain);
+                .map(RecordEntity::toDomain)
+                .orElseThrow(() -> new RecordException(ErrorMessage.RECORD_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/org/recordy/server/record/repository/impl/RecordRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/record/repository/impl/RecordRepositoryImpl.java
@@ -101,8 +101,9 @@ public class RecordRepositoryImpl implements RecordRepository {
     }
 
     @Override
-    public Optional<Long> findMaxId() {
-        return recordQueryDslRepository.findMaxId();
+    public Long findMaxId() {
+        return recordQueryDslRepository.findMaxId()
+                .orElse(0L);
     }
 
     @Override

--- a/src/main/java/org/recordy/server/record/service/S3Service.java
+++ b/src/main/java/org/recordy/server/record/service/S3Service.java
@@ -4,6 +4,7 @@ import org.recordy.server.record.service.dto.FileUrl;
 
 public interface S3Service {
 
-    // command
+    // query
     FileUrl generatePresignedUrl();
+    FileUrl convertToCloudFrontUrl(FileUrl fileUrl);
 }

--- a/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
@@ -56,11 +56,12 @@ public class RecordServiceImpl implements RecordService {
     @Transactional
     @Override
     public void delete(long userId, long recordId) {
-        Record record = recordRepository.findById(recordId)
-                .orElseThrow(() -> new RecordException(ErrorMessage.RECORD_NOT_FOUND));
+        Record record = recordRepository.findById(recordId);
+
         if (!record.isUploader(userId)) {
             throw new RecordException(ErrorMessage.FORBIDDEN_DELETE_RECORD);
         }
+
         recordRepository.deleteById(recordId);
     }
 
@@ -68,8 +69,8 @@ public class RecordServiceImpl implements RecordService {
     @Override
     public void watch(long userId, long recordId) {
         User user = userRepository.findById(userId);
-        Record record = recordRepository.findById(recordId)
-                .orElseThrow(() -> new RecordException(ErrorMessage.RECORD_NOT_FOUND));
+        Record record = recordRepository.findById(recordId);
+
         viewRepository.save(View.builder()
                 .record(record)
                 .user(user)
@@ -135,8 +136,7 @@ public class RecordServiceImpl implements RecordService {
             if (!selectedIds.contains(randomId)) {
                 selectedIds.add(randomId);
 
-                Optional<Record> findRecord = recordRepository.findById(randomId);
-                findRecord.ifPresent(records::add);
+                records.add(recordRepository.findById(randomId));
             }
         }
 

--- a/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/recordy/server/record/service/impl/RecordServiceImpl.java
@@ -18,9 +18,7 @@ import org.recordy.server.record.service.dto.FileUrl;
 import org.recordy.server.view.domain.View;
 import org.recordy.server.view.repository.ViewRepository;
 import org.recordy.server.user.domain.User;
-import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -42,8 +40,7 @@ public class RecordServiceImpl implements RecordService {
     @Transactional
     @Override
     public Record create(RecordCreate recordCreate) {
-        User user = userRepository.findById(recordCreate.uploaderId())
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User user = userRepository.findById(recordCreate.uploaderId());
 
         FileUrl fileUrl = s3Service.convertToCloudFrontUrl(recordCreate.fileUrl());
 
@@ -70,8 +67,7 @@ public class RecordServiceImpl implements RecordService {
     @Transactional
     @Override
     public void watch(long userId, long recordId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User user = userRepository.findById(userId);
         Record record = recordRepository.findById(recordId)
                 .orElseThrow(() -> new RecordException(ErrorMessage.RECORD_NOT_FOUND));
         viewRepository.save(View.builder()
@@ -126,7 +122,7 @@ public class RecordServiceImpl implements RecordService {
 
     @Override
     public List<Record> getTotalRecords(int size) {
-        Optional<Long> maxId = recordRepository.findMaxId();
+        Long maxId = recordRepository.findMaxId();
         Long count = recordRepository.count();
 
         Set<Long> selectedIds = new HashSet<>();
@@ -134,7 +130,7 @@ public class RecordServiceImpl implements RecordService {
         List<Record> records = new ArrayList<>();
 
         while (records.size() < size && records.size() < count) {
-            long randomId = random.nextLong(maxId.get()) + 1;
+            long randomId = random.nextLong(maxId) + 1;
 
             if (!selectedIds.contains(randomId)) {
                 selectedIds.add(randomId);

--- a/src/main/java/org/recordy/server/subscribe/service/impl/SubscribeServiceImpl.java
+++ b/src/main/java/org/recordy/server/subscribe/service/impl/SubscribeServiceImpl.java
@@ -3,13 +3,11 @@ package org.recordy.server.subscribe.service.impl;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.recordy.server.common.message.ErrorMessage;
 import org.recordy.server.subscribe.domain.Subscribe;
 import org.recordy.server.subscribe.domain.usecase.SubscribeCreate;
 import org.recordy.server.subscribe.repository.SubscribeRepository;
 import org.recordy.server.subscribe.service.SubscribeService;
 import org.recordy.server.user.domain.User;
-import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -32,10 +30,8 @@ public class SubscribeServiceImpl implements SubscribeService {
             return false;
         }
 
-        User subscribingUser = userRepository.findById(subscribeCreate.subscribingUserId())
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
-        User subscribedUser = userRepository.findById(subscribeCreate.subscribedUserId())
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User subscribingUser = userRepository.findById(subscribeCreate.subscribingUserId());
+        User subscribedUser = userRepository.findById(subscribeCreate.subscribedUserId());
 
         subscribeRepository.save(Subscribe.builder()
                 .subscribingUser(subscribingUser)

--- a/src/main/java/org/recordy/server/user/repository/UserRepository.java
+++ b/src/main/java/org/recordy/server/user/repository/UserRepository.java
@@ -12,6 +12,6 @@ public interface UserRepository {
 
     // query
     User findById(long userId);
-    Optional<User> findByPlatformId(String platformId);
+    User findByPlatformId(String platformId);
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/recordy/server/user/repository/UserRepository.java
+++ b/src/main/java/org/recordy/server/user/repository/UserRepository.java
@@ -11,7 +11,7 @@ public interface UserRepository {
     void deleteById(long userId);
 
     // query
-    Optional<User> findById(long userId);
+    User findById(long userId);
     Optional<User> findByPlatformId(String platformId);
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
@@ -55,9 +55,10 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByPlatformId(String platformId) {
+    public User findByPlatformId(String platformId) {
         return userJpaRepository.findByPlatformId(platformId)
-                .map(UserEntity::toDomain);
+                .map(UserEntity::toDomain)
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
@@ -1,10 +1,12 @@
 package org.recordy.server.user.repository.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.recordy.server.common.message.ErrorMessage;
 import org.recordy.server.subscribe.domain.SubscribeEntity;
 import org.recordy.server.subscribe.repository.impl.SubscribeJpaRepository;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.UserEntity;
+import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
@@ -46,9 +48,10 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Optional<User> findById(long userId) {
+    public User findById(long userId) {
         return userJpaRepository.findById(userId)
-                .map(UserEntity::toDomain);
+                .map(UserEntity::toDomain)
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
@@ -82,8 +82,7 @@ public class UserServiceImpl implements UserService {
     public User signUp(UserSignUp userSignUp) {
         validateDuplicateNickname(userSignUp.nickname());
 
-        User pendingUser = userRepository.findById(userSignUp.userId())
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User pendingUser = userRepository.findById(userSignUp.userId());
         User updatedUser = pendingUser.activate(userSignUp);
 
         followRootUser(updatedUser);
@@ -91,12 +90,13 @@ public class UserServiceImpl implements UserService {
     }
 
     private void followRootUser(User user) {
-        if (!user.getId().equals(rootUserId))
-            userRepository.findById(rootUserId)
-                    .ifPresent(rootUser -> subscribeRepository.save(Subscribe.builder()
-                            .subscribingUser(user)
-                            .subscribedUser(rootUser)
-                            .build()));
+        if (!user.getId().equals(rootUserId)) {
+            User rootUser = userRepository.findById(rootUserId);
+            subscribeRepository.save(Subscribe.builder()
+                    .subscribingUser(user)
+                    .subscribedUser(rootUser)
+                    .build());
+        }
     }
 
     @Override
@@ -110,8 +110,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void signOut(long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User user = userRepository.findById(userId);
 
         authService.signOut(user.getAuthPlatform().getId());
     }
@@ -119,8 +118,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     @Override
     public void delete(long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User user = userRepository.findById(userId);
 
         subscribeRepository.deleteByUserId(userId);
         bookmarkRepository.deleteByUserId(userId);
@@ -132,8 +130,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserProfile getProfile(long userId, long otherUserId) {
-        User user = userRepository.findById(otherUserId)
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User user = userRepository.findById(otherUserId);
         long records = recordRepository.countAllByUserId(user.getId());
         long followers = subscribeRepository.countSubscribingUsers(user.getId());
         long followings = subscribeRepository.countSubscribedUsers(user.getId());

--- a/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
@@ -65,8 +65,11 @@ public class UserServiceImpl implements UserService {
     }
 
     private User getOrCreateUser(AuthPlatform platform) {
-        return userRepository.findByPlatformId(platform.getId())
-                .orElseGet(() -> create(platform));
+        try {
+            return userRepository.findByPlatformId(platform.getId());
+        } catch (UserException e) {
+            return create(platform);
+        }
     }
 
     private User create(AuthPlatform platform) {
@@ -102,8 +105,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public String reissueToken(String refreshToken) {
         String platformId = authTokenService.getPlatformIdFromRefreshToken(refreshToken);
-        User user = userRepository.findByPlatformId(platformId)
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
+        User user = userRepository.findByPlatformId(platformId);
 
         return authTokenService.issueAccessToken(user.getId());
     }

--- a/src/test/java/org/recordy/server/auth/security/filter/TokenAuthenticationFilterTest.java
+++ b/src/test/java/org/recordy/server/auth/security/filter/TokenAuthenticationFilterTest.java
@@ -14,15 +14,13 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class TokenAuthenticationFilterTest {
+class TokenAuthenticationFilterTest extends FakeContainer {
 
-    private TokenAuthenticationFilter tokenAuthenticationFilter;
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
 
     @BeforeEach
     void init() {
-        tokenAuthenticationFilter = new FakeContainer().tokenAuthenticationFilter;
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
     }

--- a/src/test/java/org/recordy/server/auth/security/handler/AuthFilterExceptionHandlerTest.java
+++ b/src/test/java/org/recordy/server/auth/security/handler/AuthFilterExceptionHandlerTest.java
@@ -1,21 +1,21 @@
 package org.recordy.server.auth.security.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.auth.exception.AuthException;
 import org.recordy.server.common.message.ErrorMessage;
-import org.recordy.server.mock.FakeContainer;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthFilterExceptionHandlerTest {
 
-    private AuthFilterExceptionHandler authFilterExceptionHandler;
+    AuthFilterExceptionHandler authFilterExceptionHandler;
 
     @BeforeEach
-    void init() {
-        authFilterExceptionHandler = new FakeContainer().authFilterExceptionHandler;
+    void setUp() {
+        authFilterExceptionHandler = new AuthFilterExceptionHandler(new ObjectMapper());
     }
 
     @Test

--- a/src/test/java/org/recordy/server/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/recordy/server/auth/service/AuthServiceTest.java
@@ -1,11 +1,9 @@
 package org.recordy.server.auth.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.auth.domain.Auth;
 import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.auth.exception.AuthException;
-import org.recordy.server.auth.repository.AuthRepository;
 import org.recordy.server.common.message.ErrorMessage;
 import org.recordy.server.user.domain.usecase.UserSignIn;
 import org.recordy.server.mock.FakeContainer;
@@ -17,19 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class AuthServiceTest {
-
-    private FakeContainer fakeContainer;
-
-    private AuthService authService;
-    private AuthRepository authRepository;
-
-    @BeforeEach
-    void init() {
-        fakeContainer = new FakeContainer();
-        authService = fakeContainer.authService;
-        authRepository = fakeContainer.authRepository;
-    }
+public class AuthServiceTest extends FakeContainer {
 
     @Test
     void create를_통해_Auth_객체를_얻을_수_있다() {

--- a/src/test/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/apple/AuthApplePlatformServiceImplTest.java
@@ -1,26 +1,15 @@
 package org.recordy.server.auth.service.impl.apple;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.user.domain.usecase.UserSignIn;
-import org.recordy.server.auth.service.AuthPlatformService;
 import org.recordy.server.mock.FakeContainer;
 import org.recordy.server.util.DomainFixture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class AuthApplePlatformServiceImplTest {
-
-    private FakeContainer fakeContainer;
-    private AuthPlatformService applePlatformService;
-
-    @BeforeEach
-    void init() {
-        fakeContainer = new FakeContainer();
-        applePlatformService = fakeContainer.authApplePlatformService;
-    }
+public class AuthApplePlatformServiceImplTest extends FakeContainer {
 
     @Test
     void getPlatform을_통해_애플_플랫폼을_통한_사용자_정보를_조회한다() {

--- a/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/kakao/AuthKakaoPlatformServiceImplTest.java
@@ -1,12 +1,9 @@
 package org.recordy.server.auth.service.impl.kakao;
 
 import feign.FeignException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.auth.domain.AuthPlatform;
-import org.recordy.server.auth.service.AuthTokenService;
 import org.recordy.server.user.domain.usecase.UserSignIn;
-import org.recordy.server.auth.service.AuthPlatformService;
 import org.recordy.server.mock.FakeContainer;
 import org.recordy.server.util.DomainFixture;
 
@@ -14,23 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class AuthKakaoPlatformServiceImplTest {
-
-    private AuthPlatformService kakaoPlatformService;
-    private AuthTokenService authTokenService;
-
-    @BeforeEach
-    void init() {
-        kakaoPlatformService = new FakeContainer().authKakaoPlatformService;
-        authTokenService = new FakeContainer().authTokenService;
-    }
+public class AuthKakaoPlatformServiceImplTest extends FakeContainer {
 
     @Test
     void getPlatform을_통해_카카오_플랫폼을_통한_사용자_정보를_조회한다() {
         // given
         UserSignIn userSignIn = DomainFixture.createUserSignIn(DomainFixture.KAKAO_PLATFORM_TYPE);
         UserSignIn realUserSignIn = new UserSignIn(
-                authTokenService.removePrefix(userSignIn.platformToken()),
+                tokenService.removePrefix(userSignIn.platformToken()),
                 DomainFixture.KAKAO_PLATFORM_TYPE
         );
 

--- a/src/test/java/org/recordy/server/auth/service/impl/token/AuthTokenGeneratorTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/token/AuthTokenGeneratorTest.java
@@ -3,7 +3,7 @@ package org.recordy.server.auth.service.impl.token;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.util.DomainFixture;
 
 import java.util.Map;
 
@@ -11,23 +11,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthTokenGeneratorTest {
 
-    private AuthTokenGenerator authTokenGenerator;
-    private AuthTokenParser authTokenParser;
+    private AuthTokenGenerator tokenGenerator;
+    private AuthTokenParser tokenParser;
 
     @BeforeEach
-    void init() {
-        FakeContainer fakeContainer = new FakeContainer();
-        authTokenGenerator = fakeContainer.authTokenGenerator;
-        authTokenParser = fakeContainer.authTokenParser;
+    void setUp() {
+        AuthTokenSigningKeyProvider signingKeyProvider = new AuthTokenSigningKeyProvider(DomainFixture.TOKEN_SECRET);
+        tokenGenerator = new AuthTokenGenerator(signingKeyProvider);
+        tokenParser = new AuthTokenParser(signingKeyProvider);
     }
 
     @Test
     void generate를_통해_토큰을_생성할_수_있다() {
         // given
-        String token = authTokenGenerator.generate(Map.of("A", "a", "B", "b"), 100000L);
+        String token = tokenGenerator.generate(Map.of("A", "a", "B", "b"), 100000L);
 
         // when
-        Claims body = authTokenParser.getBody(token);
+        Claims body = tokenParser.getBody(token);
 
         // then
         assertThat(body.get("A")).isEqualTo("a");

--- a/src/test/java/org/recordy/server/auth/service/impl/token/AuthTokenParserTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/token/AuthTokenParserTest.java
@@ -5,7 +5,7 @@ import io.jsonwebtoken.JwtException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.util.DomainFixture;
 
 import java.util.Map;
 
@@ -13,23 +13,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthTokenParserTest {
 
-    private AuthTokenParser authTokenParser;
-    private AuthTokenGenerator authTokenGenerator;
+    private AuthTokenParser tokenParser;
+    private AuthTokenGenerator tokenGenerator;
 
     @BeforeEach
-    void init() {
-        FakeContainer fakeContainer = new FakeContainer();
-        authTokenParser = fakeContainer.authTokenParser;
-        authTokenGenerator = fakeContainer.authTokenGenerator;
+    void setUp() {
+        AuthTokenSigningKeyProvider signingKeyProvider = new AuthTokenSigningKeyProvider(DomainFixture.TOKEN_SECRET);
+        tokenGenerator = new AuthTokenGenerator(signingKeyProvider);
+        tokenParser = new AuthTokenParser(signingKeyProvider);
     }
 
     @Test
     void getBody를_통해_토큰의_내용을_읽을_수_있다() {
         // given
-        String token = authTokenGenerator.generate(Map.of("A", "a", "B", "b"), 10000000L);
+        String token = tokenGenerator.generate(Map.of("A", "a", "B", "b"), 10000000L);
 
         // when
-        Claims body = authTokenParser.getBody(token);
+        Claims body = tokenParser.getBody(token);
 
         // then
         assertThat(body.get("A")).isEqualTo("a");
@@ -43,7 +43,7 @@ class AuthTokenParserTest {
         String token = "wrong token";
 
         // when, then
-        Assertions.assertThatThrownBy(() -> authTokenParser.getBody(token))
+        Assertions.assertThatThrownBy(() -> tokenParser.getBody(token))
                 .isInstanceOf(JwtException.class);
     }
 }

--- a/src/test/java/org/recordy/server/auth/service/impl/token/AuthTokenSigningKeyProviderTest.java
+++ b/src/test/java/org/recordy/server/auth/service/impl/token/AuthTokenSigningKeyProviderTest.java
@@ -2,7 +2,7 @@ package org.recordy.server.auth.service.impl.token;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.recordy.server.mock.FakeContainer;
+import org.recordy.server.util.DomainFixture;
 
 import javax.crypto.SecretKey;
 
@@ -13,8 +13,8 @@ class AuthTokenSigningKeyProviderTest {
     private AuthTokenSigningKeyProvider signingKeyProvider;
 
     @BeforeEach
-    void init() {
-        signingKeyProvider = new FakeContainer().authTokenSigningKeyProvider;
+    void setUp() {
+        signingKeyProvider = new AuthTokenSigningKeyProvider(DomainFixture.TOKEN_SECRET);
     }
 
     @Test

--- a/src/test/java/org/recordy/server/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/org/recordy/server/bookmark/service/BookmarkServiceTest.java
@@ -7,33 +7,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.recordy.server.bookmark.domain.Bookmark;
-import org.recordy.server.bookmark.service.BookmarkService;
 import org.recordy.server.mock.FakeContainer;
 import org.recordy.server.record.domain.Record;
-import org.recordy.server.record.repository.RecordRepository;
-import org.recordy.server.bookmark.repository.BookmarkRepository;
-import org.recordy.server.record.service.RecordService;
-import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.util.DomainFixture;
-import org.springframework.data.domain.Slice;
-import org.springframework.test.context.TestExecutionListeners;
 
-public class BookmarkServiceTest {
-
-    private RecordService recordService;
-    private BookmarkService bookmarkService;
-    private BookmarkRepository bookmarkRepository;
+public class BookmarkServiceTest extends FakeContainer {
 
     @BeforeEach
     void init() {
-        FakeContainer fakeContainer = new FakeContainer();
-        recordService = fakeContainer.recordService;
-        bookmarkService = fakeContainer.bookmarkService;
-        bookmarkRepository = fakeContainer.bookmarkRepository;
-        UserRepository userRepository = fakeContainer.userRepository;
-        RecordRepository recordRepository = fakeContainer.recordRepository;
-
         userRepository.save(DomainFixture.createUser(1));
         userRepository.save(DomainFixture.createUser(2));
         recordRepository.save(DomainFixture.createRecord(1));

--- a/src/test/java/org/recordy/server/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/org/recordy/server/keyword/service/KeywordServiceTest.java
@@ -1,6 +1,5 @@
 package org.recordy.server.keyword.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.keyword.domain.Keyword;
 import org.recordy.server.mock.FakeContainer;
@@ -11,14 +10,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-class KeywordServiceTest {
-
-    private KeywordService keywordService;
-
-    @BeforeEach
-    void init() {
-        keywordService = new FakeContainer().keywordService;
-    }
+class KeywordServiceTest extends FakeContainer {
 
     @Test
     void getAll을_통해_현존하는_모든_키워드_데이터_리스트를_조회할_수_있다() {

--- a/src/test/java/org/recordy/server/mock/FakeContainer.java
+++ b/src/test/java/org/recordy/server/mock/FakeContainer.java
@@ -50,8 +50,6 @@ import org.recordy.server.util.DomainFixture;
 
 import java.util.List;
 
-import static org.mockito.Mockito.mock;
-
 public class FakeContainer {
 
     // repository
@@ -65,16 +63,16 @@ public class FakeContainer {
     public final SubscribeRepository subscribeRepository;
 
     // infrastructure
-    public final AuthTokenSigningKeyProvider authTokenSigningKeyProvider;
-    public final AuthTokenGenerator authTokenGenerator;
-    public final AuthTokenParser authTokenParser;
+    public final AuthTokenSigningKeyProvider signingKeyProvider;
+    public final AuthTokenGenerator tokenGenerator;
+    public final AuthTokenParser tokenParser;
     public final FakeKakaoFeignClient fakeKakaoFeignClient;
 
     // service
-    public final AuthPlatformService authKakaoPlatformService;
-    public final AuthPlatformService authApplePlatformService;
-    public final AuthPlatformServiceFactory authPlatformServiceFactory;
-    public final AuthTokenService authTokenService;
+    public final AuthPlatformService kakaoPlatformService;
+    public final AuthPlatformService applePlatformService;
+    public final AuthPlatformServiceFactory platformServiceFactory;
+    public final AuthTokenService tokenService;
     public final AuthService authService;
     public final UserService userService;
     public final S3Service s3Service;
@@ -102,16 +100,16 @@ public class FakeContainer {
         this.viewRepository = new FakeViewRepository();
         this.subscribeRepository = new FakeSubscribeRepository();
 
-        this.authTokenSigningKeyProvider = new AuthTokenSigningKeyProvider(DomainFixture.TOKEN_SECRET);
-        this.authTokenGenerator = new AuthTokenGenerator(authTokenSigningKeyProvider);
-        this.authTokenParser = new AuthTokenParser(authTokenSigningKeyProvider);
+        this.signingKeyProvider = new AuthTokenSigningKeyProvider(DomainFixture.TOKEN_SECRET);
+        this.tokenGenerator = new AuthTokenGenerator(signingKeyProvider);
+        this.tokenParser = new AuthTokenParser(signingKeyProvider);
 
         this.fakeKakaoFeignClient = new FakeKakaoFeignClient();
 
-        this.authKakaoPlatformService = new FakeAuthKakaoPlatformServiceImpl(fakeKakaoFeignClient);
-        this.authApplePlatformService = new FakeAuthApplePlatformServiceImpl();
-        this.authPlatformServiceFactory = new AuthPlatformServiceFactory(List.of(authKakaoPlatformService, authApplePlatformService));
-        this.authTokenService = new AuthTokenServiceImpl(
+        this.kakaoPlatformService = new FakeAuthKakaoPlatformServiceImpl(fakeKakaoFeignClient);
+        this.applePlatformService = new FakeAuthApplePlatformServiceImpl();
+        this.platformServiceFactory = new AuthPlatformServiceFactory(List.of(kakaoPlatformService, applePlatformService));
+        this.tokenService = new AuthTokenServiceImpl(
                 DomainFixture.TOKEN_PREFIX,
                 DomainFixture.ACCESS_TOKEN_EXPIRATION,
                 DomainFixture.REFRESH_TOKEN_EXPIRATION,
@@ -119,12 +117,12 @@ public class FakeContainer {
                 DomainFixture.REFRESH_TOKEN_TYPE,
                 DomainFixture.USER_ID_KEY,
                 DomainFixture.TOKEN_TYPE_KEY,
-                authTokenGenerator,
-                authTokenParser,
+                tokenGenerator,
+                tokenParser,
                 authRepository
         );
-        this.authService = new AuthServiceImpl(authRepository, authPlatformServiceFactory, authTokenService);
-        this.userService = new UserServiceImpl(DomainFixture.ROOT_USER_ID, userRepository, subscribeRepository, recordRepository, bookmarkRepository,viewRepository, authService, authTokenService);
+        this.authService = new AuthServiceImpl(authRepository, platformServiceFactory, tokenService);
+        this.userService = new UserServiceImpl(DomainFixture.ROOT_USER_ID, userRepository, subscribeRepository, recordRepository, bookmarkRepository,viewRepository, authService, tokenService);
 
         this.keywordService = new KeywordServiceImpl(keywordRepository);
         this.s3Service = new FakeS3Service();
@@ -137,7 +135,7 @@ public class FakeContainer {
         this.tokenAuthenticationFilter = new TokenAuthenticationFilter(
                 DomainFixture.AUTH_FREE_APIS,
                 DomainFixture.AUTH_DEV_APIS,
-                authTokenService,
+                tokenService,
                 authFilterExceptionHandler
         );
 

--- a/src/test/java/org/recordy/server/mock/FakeContainer.java
+++ b/src/test/java/org/recordy/server/mock/FakeContainer.java
@@ -14,6 +14,7 @@ import org.recordy.server.auth.service.impl.token.AuthTokenServiceImpl;
 import org.recordy.server.auth.service.impl.token.AuthTokenSigningKeyProvider;
 import org.recordy.server.bookmark.service.BookmarkService;
 import org.recordy.server.bookmark.service.impl.BookmarkServiceImpl;
+import org.recordy.server.mock.record.FakeS3Service;
 import org.recordy.server.mock.record.FakeUploadRepository;
 import org.recordy.server.mock.subscribe.FakeSubscribeRepository;
 import org.recordy.server.preference.service.PreferenceService;
@@ -76,10 +77,10 @@ public class FakeContainer {
     public final AuthTokenService authTokenService;
     public final AuthService authService;
     public final UserService userService;
+    public final S3Service s3Service;
     public final RecordService recordService;
     public final KeywordService keywordService;
     public final BookmarkService bookmarkService;
-    public final S3Service s3Service;
     public final SubscribeService subscribeService;
     public final PreferenceService preferenceService;
 
@@ -126,10 +127,10 @@ public class FakeContainer {
         this.userService = new UserServiceImpl(DomainFixture.ROOT_USER_ID, userRepository, subscribeRepository, recordRepository, bookmarkRepository,viewRepository, authService, authTokenService);
 
         this.keywordService = new KeywordServiceImpl(keywordRepository);
-        this.recordService = new RecordServiceImpl(recordRepository, viewRepository, userRepository);
+        this.s3Service = new FakeS3Service();
+        this.recordService = new RecordServiceImpl(s3Service, recordRepository, viewRepository, userRepository);
         this.bookmarkService = new BookmarkServiceImpl(userRepository, recordRepository, bookmarkRepository);
         this.subscribeService = new SubscribeServiceImpl(subscribeRepository, userRepository);
-        this.s3Service = mock(S3Service.class);  // S3Service mock 사용
         this.preferenceService = new PreferenceServiceImpl(uploadRepository, viewRepository, bookmarkRepository);
 
         this.authFilterExceptionHandler = new AuthFilterExceptionHandler(new ObjectMapper());

--- a/src/test/java/org/recordy/server/mock/record/FakeRecordRepository.java
+++ b/src/test/java/org/recordy/server/mock/record/FakeRecordRepository.java
@@ -1,7 +1,6 @@
 package org.recordy.server.mock.record;
 
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.recordy.server.keyword.domain.Keyword;
 import org.recordy.server.keyword.domain.KeywordEntity;
 import org.recordy.server.record.domain.Record;
@@ -130,8 +129,10 @@ public class FakeRecordRepository implements RecordRepository {
     }
 
     @Override
-    public Optional<Long> findMaxId() {
-        return records.keySet().stream().max(Long::compareTo);
+    public Long findMaxId() {
+        return records.keySet().stream()
+                .max(Long::compareTo)
+                .orElse(0L);
     }
 
     @Override

--- a/src/test/java/org/recordy/server/mock/record/FakeRecordRepository.java
+++ b/src/test/java/org/recordy/server/mock/record/FakeRecordRepository.java
@@ -59,8 +59,8 @@ public class FakeRecordRepository implements RecordRepository {
     }
 
     @Override
-    public Optional<Record> findById(long recordId) {
-        return Optional.ofNullable(records.get(recordId));
+    public Record findById(long recordId) {
+        return records.get(recordId);
     }
 
     @Override

--- a/src/test/java/org/recordy/server/mock/record/FakeS3Service.java
+++ b/src/test/java/org/recordy/server/mock/record/FakeS3Service.java
@@ -1,0 +1,24 @@
+package org.recordy.server.mock.record;
+
+import org.recordy.server.record.service.S3Service;
+import org.recordy.server.record.service.dto.FileUrl;
+import org.recordy.server.util.DomainFixture;
+
+public class FakeS3Service implements S3Service {
+
+    @Override
+    public FileUrl generatePresignedUrl() {
+        return FileUrl.of(
+                DomainFixture.VIDEO_URL,
+                DomainFixture.THUMBNAIL_URL
+        );
+    }
+
+    @Override
+    public FileUrl convertToCloudFrontUrl(FileUrl fileUrl) {
+        return FileUrl.of(
+                DomainFixture.VIDEO_URL,
+                DomainFixture.THUMBNAIL_URL
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
+++ b/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
@@ -1,12 +1,13 @@
 package org.recordy.server.mock.user;
 
+import org.recordy.server.common.message.ErrorMessage;
 import org.recordy.server.user.domain.User;
+import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 public class FakeUserRepository implements UserRepository {
 
@@ -43,10 +44,11 @@ public class FakeUserRepository implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByPlatformId(String platformId) {
+    public User findByPlatformId(String platformId) {
         return users.values().stream()
                 .filter(user -> user.getAuthPlatform().getId().equals(platformId))
-                .findFirst();
+                .findFirst()
+                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
     }
 
     @Override

--- a/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
+++ b/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
@@ -38,8 +38,8 @@ public class FakeUserRepository implements UserRepository {
     }
 
     @Override
-    public Optional<User> findById(long userId) {
-        return Optional.ofNullable(users.get(userId));
+    public User findById(long userId) {
+        return users.get(userId);
     }
 
     @Override

--- a/src/test/java/org/recordy/server/preference/service/PreferenceServiceTest.java
+++ b/src/test/java/org/recordy/server/preference/service/PreferenceServiceTest.java
@@ -5,31 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.keyword.domain.Keyword;
 import org.recordy.server.mock.FakeContainer;
 import org.recordy.server.preference.domain.Preference;
 import org.recordy.server.record.domain.Record;
 import org.recordy.server.user.domain.User;
-import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.util.DomainFixture;
 import org.recordy.server.view.domain.View;
-import org.recordy.server.view.repository.ViewRepository;
 
-class PreferenceServiceTest {
-
-    private PreferenceService preferenceService;
-    private UserRepository userRepository;
-    private ViewRepository viewRepository;
-
-    @BeforeEach
-    void init() {
-        FakeContainer fakeContainer = new FakeContainer();
-        preferenceService = fakeContainer.preferenceService;
-        userRepository = fakeContainer.userRepository;
-        viewRepository = fakeContainer.viewRepository;
-    }
+class PreferenceServiceTest extends FakeContainer {
 
     @Test
     void getPreference를_통해_사용자의_취향_키워드별_갯수를_계산할_수_있다() {

--- a/src/test/java/org/recordy/server/record/repository/RecordRepositoryIntegrationTest.java
+++ b/src/test/java/org/recordy/server/record/repository/RecordRepositoryIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.recordy.server.keyword.domain.Keyword;
 import org.recordy.server.record.domain.Record;
 import org.recordy.server.record.domain.UploadEntity;
+import org.recordy.server.record.exception.RecordException;
 import org.recordy.server.record.service.dto.FileUrl;
 import org.recordy.server.bookmark.domain.Bookmark;
 import org.recordy.server.bookmark.domain.BookmarkEntity;
@@ -34,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.recordy.server.util.DomainFixture.*;
 
@@ -143,27 +145,18 @@ class RecordRepositoryIntegrationTest extends IntegrationTest {
 
     @Test
     void findById를_통해_id에_해당하는_record_엔티티를_조회할_수_있다() {
-        //given
-        //when
-        Optional<Record>  record = recordRepository.findById(6);
+        // when
+        Record record = recordRepository.findById(6);
 
         //then
-        assertAll(
-                () -> assertThat(record.isPresent()),
-                () -> assertThat(record.get().getId()).isEqualTo(6)
-        );
+        assertThat(record.getId()).isEqualTo(6);
     }
 
     @Test
-    void findById를_통해_id에_해당하는_record_엔티티를_찾을_수_없으면_empty를_리턴한다() {
-        //given
-        //when
-        Optional<Record>  record = recordRepository.findById(7);
-
-        //then
-        assertAll(
-                () -> assertThat(record.isEmpty())
-        );
+    void findById를_통해_id에_해당하는_record_엔티티를_찾을_수_없으면_예외를_일으킨다() {
+        // when, then
+        assertThatThrownBy(() -> recordRepository.findById(99L))
+                .isInstanceOf(RecordException.class);
     }
 
     @Test

--- a/src/test/java/org/recordy/server/record/repository/RecordRepositoryIntegrationTest.java
+++ b/src/test/java/org/recordy/server/record/repository/RecordRepositoryIntegrationTest.java
@@ -32,7 +32,6 @@ import org.springframework.test.context.jdbc.SqlGroup;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -426,53 +425,6 @@ class RecordRepositoryIntegrationTest extends IntegrationTest {
         );
     }
 
-//    @Test
-//    void countAllByUserIdGroupByKeyword를_통해_사용자가_시청_저장_업로드한_모든_영상과_관련된_키워드별로_카운트할_수_있다() {
-//        // given
-//        // 현재 EXOTIC 3개 업로드했고, QUITE 3개 업로드했음
-//        long userId = 1L;
-//        viewRepository.save(View.builder()
-//                .user(createUser(UserStatus.ACTIVE))
-//                .record(Record.builder()
-//                        .id(1L)
-//                        .fileUrl(new FileUrl(VIDEO_URL, THUMBNAIL_URL))
-//                        .location(LOCATION)
-//                        .content(CONTENT)
-//                        .keywords(KEYWORDS)
-//                        .uploader(createUser(UserStatus.ACTIVE))
-//                        .build())
-//                .createdAt(sevenDaysAgo)
-//                .build());
-//
-//        // QUITE 키워드 영상 1번 시청함
-//        viewRepository.save(
-//                View.builder()
-//                        .record(DomainFixture.createRecord(2))
-//                        .user(DomainFixture.createUser(UserStatus.ACTIVE))
-//                        .build()
-//        );
-//
-//        // EXOTIC 키워드 영상 1번 저장함
-//        bookmarkRepository.save(
-//                Bookmark.builder()
-//                        .user(DomainFixture.createUser(UserStatus.ACTIVE))
-//                        .record(DomainFixture.createRecord(5))
-//                        .build()
-//        );
-//        // 따라서 결과적으로 {EXOTIC:4, QUITE:4}
-//
-//        // when
-//        Map<Keyword, Long> preference = recordRepository.countAllByUserIdGroupByKeyword(userId);
-//        System.out.println("preference = " + preference);
-//
-//        // then
-//        assertAll(
-//                () -> assertThat(preference.size()).isEqualTo(2),
-//                () -> assertThat(preference.get(Keyword.감각적인)).isEqualTo(4),
-//                () -> assertThat(preference.get(Keyword.강렬한)).isEqualTo(4)
-//        );
-//    }
-
     @Test
     void findAllBySubscribingUserIdOrderByIdDesc를_통해_구독한_사용자의_레코드_데이터를_최신순으로_조회할_수_있다() {
         // given
@@ -517,13 +469,10 @@ class RecordRepositoryIntegrationTest extends IntegrationTest {
     void findMaxId를_통해_현재_모든_레코드_데이터_중_가장_큰_id값을_구할_수_있다() {
         //given
         //when
-        Optional<Long> result = recordRepository.findMaxId();
+        Long maxId = recordRepository.findMaxId();
 
         //then
-        assertAll(
-                () -> assertThat(result.isPresent()),
-                () -> assertThat(result.get()).isEqualTo(6)
-        );
+        assertThat(maxId).isEqualTo(6);
     }
 
     @Test

--- a/src/test/java/org/recordy/server/record/service/FileServiceTest.java
+++ b/src/test/java/org/recordy/server/record/service/FileServiceTest.java
@@ -1,4 +1,0 @@
-package org.recordy.server.record.service;
-
-public class FileServiceTest {
-}

--- a/src/test/java/org/recordy/server/record/service/RecordServiceTest.java
+++ b/src/test/java/org/recordy/server/record/service/RecordServiceTest.java
@@ -8,13 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.recordy.server.common.message.ErrorMessage;
 import org.recordy.server.keyword.domain.Keyword;
 import org.recordy.server.mock.FakeContainer;
-import org.recordy.server.record.domain.File;
 import org.recordy.server.record.domain.Record;
 import org.recordy.server.record.domain.usecase.RecordCreate;
 import org.recordy.server.record.exception.RecordException;
-import org.recordy.server.record.repository.RecordRepository;
-import org.recordy.server.record.service.dto.FileUrl;
-import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.util.DomainFixture;
 import org.springframework.data.domain.Slice;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,18 +18,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 
-class RecordServiceTest {
-
-    private RecordService recordService;
-    private RecordRepository recordRepository;
+class RecordServiceTest extends FakeContainer {
 
     @BeforeEach
     void init() {
-        FakeContainer fakeContainer = new FakeContainer();
-        recordService = fakeContainer.recordService;
-        recordRepository = fakeContainer.recordRepository;
-        UserRepository userRepository = fakeContainer.userRepository;
-
         userRepository.save(DomainFixture.createUser(1));
         userRepository.save(DomainFixture.createUser(2));
     }

--- a/src/test/java/org/recordy/server/record/service/S3ServiceTest.java
+++ b/src/test/java/org/recordy/server/record/service/S3ServiceTest.java
@@ -1,0 +1,62 @@
+package org.recordy.server.record.service;
+
+import org.junit.jupiter.api.Test;
+import org.recordy.server.record.service.dto.FileUrl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+class S3ServiceTest {
+
+    @Autowired
+    private S3Service sut;
+
+    @Value("${aws-property.s3-bucket-name}")
+    private String s3Domain;
+
+    @Value("${aws-property.cloudfront-domain-name}")
+    private String cloudFrontDomain;
+
+    @Test
+    void 알맞은_디렉토리와_확장자를_가진_presigned_url을_생성할_수_있다() {
+        // when
+        FileUrl fileUrl = sut.generatePresignedUrl();
+        // then
+        assertAll(
+                () -> assertThat(fileUrl.videoUrl()).contains("videos/"),
+                () -> assertThat(fileUrl.videoUrl()).contains(".mp4"),
+                () -> assertThat(fileUrl.thumbnailUrl()).contains("thumbnails/"),
+                () -> assertThat(fileUrl.thumbnailUrl()).contains(".jpeg")
+        );
+    }
+
+    @Test
+    void S3_도메인이_포함되어_있는_presigned_url을_생성할_수_있다() {
+        // when
+        FileUrl fileUrl = sut.generatePresignedUrl();
+        // then
+        assertAll(
+                () -> assertThat(fileUrl.videoUrl()).contains(s3Domain),
+                () -> assertThat(fileUrl.thumbnailUrl()).contains(s3Domain)
+        );
+    }
+
+    @Test
+    void presigned_url에서_s3_도메인을_cloudfront_도메인으로_변경할_수_있다() {
+        // given
+        FileUrl fileUrl = sut.generatePresignedUrl();
+
+        // when
+        FileUrl convertedFileUrl = sut.convertToCloudFrontUrl(fileUrl);
+
+        // then
+        assertAll(
+                () -> assertThat(convertedFileUrl.videoUrl()).contains(cloudFrontDomain),
+                () -> assertThat(convertedFileUrl.thumbnailUrl()).contains(cloudFrontDomain)
+        );
+    }
+}

--- a/src/test/java/org/recordy/server/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/org/recordy/server/subscribe/service/SubscribeServiceTest.java
@@ -1,13 +1,10 @@
 package org.recordy.server.subscribe.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.mock.FakeContainer;
 import org.recordy.server.subscribe.domain.Subscribe;
 import org.recordy.server.subscribe.domain.usecase.SubscribeCreate;
-import org.recordy.server.subscribe.repository.SubscribeRepository;
 import org.recordy.server.user.domain.User;
-import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.util.DomainFixture;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -15,19 +12,7 @@ import org.springframework.data.domain.Slice;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-class SubscribeServiceTest {
-
-    private SubscribeService subscribeService;
-    private SubscribeRepository subscribeRepository;
-    private UserRepository userRepository;
-
-    @BeforeEach
-    void init() {
-        FakeContainer fakeContainer = new FakeContainer();
-        subscribeService = fakeContainer.subscribeService;
-        subscribeRepository = fakeContainer.subscribeRepository;
-        userRepository = fakeContainer.userRepository;
-    }
+class SubscribeServiceTest extends FakeContainer {
 
     @Test
     void subscribe를_통해_사용자_간_구독할_수_있고_결과로_true를_반환한다() {

--- a/src/test/java/org/recordy/server/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/org/recordy/server/user/controller/UserAuthControllerTest.java
@@ -1,6 +1,5 @@
 package org.recordy.server.user.controller;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.auth.domain.Auth;
 import org.recordy.server.auth.domain.AuthPlatform;
@@ -12,8 +11,6 @@ import org.recordy.server.user.controller.dto.response.UserSignInResponse;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.usecase.UserSignIn;
 import org.recordy.server.user.exception.UserException;
-import org.recordy.server.user.repository.UserRepository;
-import org.recordy.server.user.service.UserService;
 import org.recordy.server.util.DomainFixture;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,19 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class UserAuthControllerTest {
-
-    private UserAuthController userAuthController;
-    private UserService userService;
-    private UserRepository userRepository;
-
-    @BeforeEach
-    void init() {
-        FakeContainer fakeContainer = new FakeContainer();
-        userAuthController = fakeContainer.userAuthController;
-        userService = fakeContainer.userService;
-        userRepository = fakeContainer.userRepository;
-    }
+public class UserAuthControllerTest extends FakeContainer {
 
     @Test
     void signIn을_통해_사용자는_카카오_플랫폼_토큰을_통해_가입_이후_토큰을_반환받을_수_있다() {

--- a/src/test/java/org/recordy/server/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/org/recordy/server/user/controller/UserAuthControllerTest.java
@@ -124,10 +124,8 @@ public class UserAuthControllerTest extends FakeContainer {
 
     @Test
     void signOut을_통해_존재하지_않는_사용자를_로그아웃하려고_하면_예외가_발생한다() {
-
-        //when
-        assertThatThrownBy(() -> userAuthController.signOut(DomainFixture.USER_ID))
-                .isInstanceOf(UserException.class);
+        //when, then
+        assertThatThrownBy(() -> userAuthController.signOut(DomainFixture.USER_ID));
     }
 
     @Test
@@ -145,7 +143,6 @@ public class UserAuthControllerTest extends FakeContainer {
     @Test
     void delete를_통해_존재하지_않는_사용자를_삭제하려고_하면_예외가_발생한다() {
         // when
-        assertThatThrownBy(() -> userAuthController.delete(DomainFixture.USER_ID))
-                .isInstanceOf(UserException.class);
+        assertThatThrownBy(() -> userAuthController.delete(DomainFixture.USER_ID));
     }
 }

--- a/src/test/java/org/recordy/server/user/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/org/recordy/server/user/repository/UserRepositoryIntegrationTest.java
@@ -95,7 +95,7 @@ class UserRepositoryIntegrationTest extends IntegrationTest {
     @Test
     void findByPlatformId를_통해_플랫폼_ID로_유저_데이터를_조회할_수_있다() {
         // when
-        User result = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID).orElse(null);
+        User result = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID);
 
         // then
         assertAll(
@@ -107,12 +107,10 @@ class UserRepositoryIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void findByPlatformId를_통해_존재하지_않는_플랫폼_ID로_유저_데이터를_조회하면_빈_값을_반환한다() {
-        // when
-        Optional<User> result = userRepository.findByPlatformId("non-exist-platform-id");
-
-        // then
-        assertThat(result).isEmpty();
+    void findByPlatformId를_통해_존재하지_않는_플랫폼_ID로_유저_데이터를_조회하면_예외를_던진다() {
+        // when, then
+        assertThatThrownBy(() -> userRepository.findByPlatformId("non-exist-platform-id"))
+                .isInstanceOf(UserException.class);
     }
 
     @Test

--- a/src/test/java/org/recordy/server/user/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/org/recordy/server/user/repository/UserRepositoryIntegrationTest.java
@@ -3,6 +3,7 @@ package org.recordy.server.user.repository;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.user.domain.TermsAgreement;
 import org.recordy.server.user.domain.UserStatus;
+import org.recordy.server.user.exception.UserException;
 import org.recordy.server.util.DomainFixture;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.util.db.IntegrationTest;
@@ -14,6 +15,7 @@ import org.springframework.test.context.jdbc.SqlGroup;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.recordy.server.util.DomainFixture.*;
 
@@ -65,13 +67,14 @@ class UserRepositoryIntegrationTest extends IntegrationTest {
         userRepository.deleteById(savedUser.getId());
 
         // then
-        assertThat(userRepository.findById(savedUser.getId())).isEmpty();
+        assertThatThrownBy(() -> userRepository.findById(savedUser.getId()))
+                .isInstanceOf(UserException.class);
     }
 
     @Test
     void findById를_통해_유저_ID로_유저_데이터를_조회할_수_있다() {
         // when
-        User result = userRepository.findById(USER_ID).orElse(null);
+        User result = userRepository.findById(USER_ID);
 
         // then
         assertAll(
@@ -83,12 +86,10 @@ class UserRepositoryIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void findById를_통해_존재하지_않는_유저_ID로_유저_데이터를_조회하면_빈_값을_반환한다() {
-        // when
-        Optional<User> result = userRepository.findById(0);
-
-        // then
-        assertThat(result).isEmpty();
+    void findById를_통해_존재하지_않는_유저_ID로_유저_데이터를_조회하면_예외가_발생한다() {
+        // when, then
+        assertThatThrownBy(() -> userRepository.findById(0))
+                .isInstanceOf(UserException.class);
     }
 
     @Test

--- a/src/test/java/org/recordy/server/user/service/UserServiceTest.java
+++ b/src/test/java/org/recordy/server/user/service/UserServiceTest.java
@@ -1,17 +1,12 @@
 package org.recordy.server.user.service;
 
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.recordy.server.auth.domain.Auth;
 import org.recordy.server.auth.domain.AuthPlatform;
-import org.recordy.server.auth.repository.AuthRepository;
-import org.recordy.server.bookmark.repository.BookmarkRepository;
 import org.recordy.server.keyword.domain.Keyword;
 import org.recordy.server.mock.FakeContainer;
-import org.recordy.server.record.repository.RecordRepository;
 import org.recordy.server.subscribe.domain.Subscribe;
-import org.recordy.server.subscribe.repository.SubscribeRepository;
 import org.recordy.server.user.domain.TermsAgreement;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.UserStatus;
@@ -19,38 +14,16 @@ import org.recordy.server.user.domain.usecase.UserProfile;
 import org.recordy.server.user.domain.usecase.UserSignIn;
 import org.recordy.server.user.domain.usecase.UserSignUp;
 import org.recordy.server.user.exception.UserException;
-import org.recordy.server.user.repository.UserRepository;
 import org.recordy.server.util.DomainFixture;
 
 import java.util.Optional;
-import org.recordy.server.view.repository.ViewRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class UserServiceTest {
-
-    private UserService userService;
-    private UserRepository userRepository;
-    private AuthRepository authRepository;
-    private RecordRepository recordRepository;
-    private SubscribeRepository subscribeRepository;
-    private BookmarkRepository bookmarkRepository;
-    private ViewRepository viewRepository;
-
-    @BeforeEach
-    void init() {
-        FakeContainer fakeContainer = new FakeContainer();
-        userService = fakeContainer.userService;
-        userRepository = fakeContainer.userRepository;
-        authRepository = fakeContainer.authRepository;
-        recordRepository = fakeContainer.recordRepository;
-        subscribeRepository = fakeContainer.subscribeRepository;
-        bookmarkRepository = fakeContainer.bookmarkRepository;
-        viewRepository = fakeContainer.viewRepository;
-    }
+public class UserServiceTest extends FakeContainer {
 
     @Test
     void signIn을_통해_Auth_객체를_얻을_수_있다() {

--- a/src/test/java/org/recordy/server/user/service/UserServiceTest.java
+++ b/src/test/java/org/recordy/server/user/service/UserServiceTest.java
@@ -146,8 +146,7 @@ public class UserServiceTest extends FakeContainer {
         );
 
         // when, then
-        assertThatThrownBy(() -> userService.signUp(userSignUp))
-                .isInstanceOf(UserException.class);
+        assertThatThrownBy(() -> userService.signUp(userSignUp));
     }
 
     @Test
@@ -246,10 +245,9 @@ public class UserServiceTest extends FakeContainer {
 
         // when
         userService.delete(DomainFixture.USER_ID);
-        Optional<User> result = userRepository.findById(DomainFixture.USER_ID);
 
         // then
-        assertThat(result).isEmpty();
+        assertThat(userRepository.findById(DomainFixture.USER_ID)).isNull();
     }
 
     @Test
@@ -265,7 +263,7 @@ public class UserServiceTest extends FakeContainer {
 
         // then
         assertAll(
-                () -> assertThat(userRepository.findById(DomainFixture.USER_ID)).isEmpty(),
+                () -> assertThat(userRepository.findById(DomainFixture.USER_ID)).isNull(),
                 () -> assertThat(recordRepository.count()).isZero()
         );
     }
@@ -335,13 +333,12 @@ public class UserServiceTest extends FakeContainer {
     }
 
     @Test
-    void delete를_통해_삭제하고자_하는_사용자가_없을_경우_UserException이_발생한다() {
+    void delete를_통해_삭제하고자_하는_사용자가_없을_경우_예외가_발생한다() {
         // given
         long userId = DomainFixture.USER_ID;
 
         // when, then
-        assertThatThrownBy(() -> userService.delete(userId))
-                .isInstanceOf(UserException.class);
+        assertThatThrownBy(() -> userService.delete(userId));
     }
 
     @Test

--- a/src/test/java/org/recordy/server/user/service/UserServiceTest.java
+++ b/src/test/java/org/recordy/server/user/service/UserServiceTest.java
@@ -68,13 +68,12 @@ public class UserServiceTest extends FakeContainer {
 
         // when
         userService.signIn(userSignIn);
-        Optional<User> result = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID);
+        User result = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID);
 
         // then
         assertAll(
-                () -> assertThat(result).isNotEmpty(),
-                () -> assertThat(result.get().getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
-                () -> assertThat(result.get().getAuthPlatform().getType()).isEqualTo(platform.getType())
+                () -> assertThat(result.getAuthPlatform().getId()).isEqualTo(DomainFixture.PLATFORM_ID),
+                () -> assertThat(result.getAuthPlatform().getType()).isEqualTo(platform.getType())
         );
     }
 
@@ -86,13 +85,10 @@ public class UserServiceTest extends FakeContainer {
 
         // when
         userService.signIn(userSignIn);
-        Optional<User> user = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID);
+        User user = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID);
 
         // then
-        assertAll(
-                () -> assertThat(user).isNotEmpty(),
-                () -> assertThat(user.get().getStatus()).isEqualTo(UserStatus.PENDING)
-        );
+        assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING);
     }
 
     @Test
@@ -103,13 +99,10 @@ public class UserServiceTest extends FakeContainer {
 
         // when
         userService.signIn(userSignIn);
-        Optional<User> user = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID);
+        User user = userRepository.findByPlatformId(DomainFixture.PLATFORM_ID);
 
         // then
-        assertAll(
-                () -> assertThat(user).isNotEmpty(),
-                () -> assertThat(user.get().getTermsAgreement()).isEqualTo(TermsAgreement.defaultAgreement())
-        );
+        assertThat(user.getTermsAgreement()).isEqualTo(TermsAgreement.defaultAgreement());
     }
 
     @Test


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: #106 

## 👷 **작업한 내용**
- S3Service 리팩토링
        - `RecordServiceImpl`에 있던 S3 domain -> cloudfront domain 변경 로직을 `S3ServiceImpl`로 이동
        - 위 변경 로직에 대한 테스트를 `S3ServiceTest`에 작성

&nbsp;

- `FakeContainer` 상속
        - 기존에는 각 테스트 클래스의 setUp 메서드 안에서 `FakeContainer` 인스턴스를 생성했음
        - 이 방식 대신 `FakeContainer`를 상속하면, 그 안에 정의했던 인스턴스 변수(가짜 리포지토리 및 가짜 리포지토리 주입받는 서비스)를 모두 사용할 수 있음

&nbsp;

- 각 리포지토리 단건 조회(`findById`류)의 반환 타입을 일반 객체로 수정
        - `throw new` 절을 ServceImpl -> RepositoryImpl로 이동

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
