### PR TITLE
signUp 이전에 rootUser 팔로우하는 문제 수정

### DIFF
--- a/src/main/java/org/recordy/server/user/domain/User.java
+++ b/src/main/java/org/recordy/server/user/domain/User.java
@@ -62,7 +62,7 @@ public class User {
                 .build();
     }
 
-    public UserUpdate confirmUpdate(UserUpdate update) {
+    public void update(UserUpdate update) {
         if (Objects.nonNull(update.nickname())) {
             validateNicknameFormat(update.nickname());
             nickname = update.nickname();
@@ -75,7 +75,6 @@ public class User {
         else {
             profileImageUrl = PROFILE_IMAGE_URL;
         }
-        return  new UserUpdate(nickname, profileImageUrl);
     }
 
     private void validateNicknameFormat(String nickname) {

--- a/src/main/java/org/recordy/server/user/domain/UserEntity.java
+++ b/src/main/java/org/recordy/server/user/domain/UserEntity.java
@@ -10,12 +10,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.recordy.server.auth.domain.AuthPlatform;
 import org.recordy.server.common.domain.JpaMetaInfoEntity;
 import org.recordy.server.subscribe.domain.SubscribeEntity;
@@ -34,19 +33,17 @@ public class UserEntity extends JpaMetaInfoEntity {
     private AuthPlatform.Type platformType;
     @Enumerated(EnumType.STRING)
     private UserStatus status;
-    @Setter
     private String profileImageUrl;
-    @Setter
     private String nickname;
     private boolean useTerm;
     private boolean personalInfoTerm;
     private boolean ageTerm;
 
-    @OneToMany(mappedBy = "subscribingUser", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SubscribeEntity> subscribings = new ArrayList<>();
+    @OneToMany(mappedBy = "subscribingUser", cascade = CascadeType.ALL)
+    private Set<SubscribeEntity> subscribings = new HashSet<>();
 
-    @OneToMany(mappedBy = "subscribedUser", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SubscribeEntity> subscribers = new ArrayList<>();
+    @OneToMany(mappedBy = "subscribedUser", cascade = CascadeType.ALL)
+    private Set<SubscribeEntity> subscribers = new HashSet<>();
 
     public UserEntity(
             Long id,

--- a/src/main/java/org/recordy/server/user/repository/UserRepository.java
+++ b/src/main/java/org/recordy/server/user/repository/UserRepository.java
@@ -3,7 +3,6 @@ package org.recordy.server.user.repository;
 import org.recordy.server.user.controller.dto.response.UserInfo;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.usecase.UserProfile;
-import org.recordy.server.user.domain.usecase.UserUpdate;
 import org.springframework.data.domain.Slice;
 
 public interface UserRepository {
@@ -11,7 +10,6 @@ public interface UserRepository {
     // command
     User save(User user);
     void deleteById(long id);
-    void update(long userId, UserUpdate update);
 
     // query
     User findById(long id);

--- a/src/main/java/org/recordy/server/user/repository/impl/UserQueryDslRepository.java
+++ b/src/main/java/org/recordy/server/user/repository/impl/UserQueryDslRepository.java
@@ -13,6 +13,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.recordy.server.common.util.QueryDslUtils;
+import org.recordy.server.subscribe.domain.QSubscribeEntity;
 import org.recordy.server.user.controller.dto.response.UserInfo;
 import org.recordy.server.user.domain.UserEntity;
 import org.recordy.server.user.domain.usecase.UserProfile;
@@ -24,10 +25,14 @@ import org.springframework.stereotype.Repository;
 public class UserQueryDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+    QSubscribeEntity subscribeEntity1 = new QSubscribeEntity("subscribe1");
+    QSubscribeEntity subscribeEntity2 = new QSubscribeEntity("subscribe2");
 
     public UserEntity findById(long userId) {
         return jpaQueryFactory
                 .selectFrom(userEntity)
+                .leftJoin(userEntity.subscribers, subscribeEntity1).fetchJoin()
+                .leftJoin(userEntity.subscribings, subscribeEntity2).fetchJoin()
                 .where(userEntity.id.eq(userId))
                 .fetchOne();
     }

--- a/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
@@ -3,7 +3,6 @@ package org.recordy.server.user.repository.impl;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.recordy.server.common.message.ErrorMessage;
-import org.recordy.server.subscribe.domain.SubscribeEntity;
 import org.recordy.server.subscribe.repository.impl.SubscribeJpaRepository;
 import org.recordy.server.user.controller.dto.response.UserInfo;
 import org.recordy.server.user.domain.User;
@@ -29,20 +28,8 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public User save(User user) {
         UserEntity entity = userJpaRepository.save(UserEntity.from(user));
-        followRootUser(entity);
 
         return User.from(entity);
-    }
-
-    private void followRootUser(UserEntity userEntity) {
-        if (!userEntity.getId().equals(rootUserId)) {
-            userJpaRepository.findById(rootUserId)
-                    .ifPresent(rootUser -> subscribeJpaRepository.save(SubscribeEntity.builder()
-                            .subscribingUser(userEntity)
-                            .subscribedUser(rootUser)
-                            .build())
-                    );
-        }
     }
 
     @Override

--- a/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/org/recordy/server/user/repository/impl/UserRepositoryImpl.java
@@ -9,7 +9,6 @@ import org.recordy.server.user.controller.dto.response.UserInfo;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.UserEntity;
 import org.recordy.server.user.domain.usecase.UserProfile;
-import org.recordy.server.user.domain.usecase.UserUpdate;
 import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,15 +48,6 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public void deleteById(long id) {
         userJpaRepository.deleteById(id);
-    }
-
-    @Override
-    public void update(long id, UserUpdate update) {
-        UserEntity userEntity = userJpaRepository.findById(id)
-                .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
-
-        userEntity.setNickname(update.nickname());
-        userEntity.setProfileImageUrl(update.profileImageUrl());
     }
 
     @Override

--- a/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/recordy/server/user/service/impl/UserServiceImpl.java
@@ -124,7 +124,8 @@ public class UserServiceImpl implements UserService {
         if (!user.getNickname().equals(update.nickname())) {
             validateDuplicateNickname(update.nickname());
         }
-        userRepository.update(id, user.confirmUpdate(update));
+        user.update(update);
+        userRepository.save(user);
     }
 
     @Transactional

--- a/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
+++ b/src/test/java/org/recordy/server/mock/user/FakeUserRepository.java
@@ -7,7 +7,6 @@ import org.recordy.server.common.message.ErrorMessage;
 import org.recordy.server.user.controller.dto.response.UserInfo;
 import org.recordy.server.user.domain.User;
 import org.recordy.server.user.domain.usecase.UserProfile;
-import org.recordy.server.user.domain.usecase.UserUpdate;
 import org.recordy.server.user.exception.UserException;
 import org.recordy.server.user.repository.UserRepository;
 import org.springframework.data.domain.Slice;
@@ -39,17 +38,6 @@ public class FakeUserRepository implements UserRepository {
     @Override
     public void deleteById(long id) {
         users.remove(id);
-    }
-
-    @Override
-    public void update(long userId, UserUpdate update) {
-        User user = users.get(userId);
-        if (user == null) {
-            throw new UserException(ErrorMessage.USER_NOT_FOUND);
-        }
-        User updatedUser = new User(user.getId(), user.getAuthPlatform(), user.getStatus(), update.profileImageUrl(),
-                update.nickname(), user.getTermsAgreement(), user.getCreatedAt(), user.getUpdatedAt());
-        users.put(userId, updatedUser);
     }
 
     @Override


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: #125 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
-   user save시  followRootUser를 호출하는 로직을 제거했습니다.

    - 어차피 signUp에서 루트유저를 팔로우하는 로직이 존재하기에 save할 때마다 followRootUser를 호출하는 로직은 제거해도 상관이 없을 것 같습니다. 오히려 중복 로직을 제거해야 중복 구독 정보를  넣을 때 발생하는 오류를 해결할 수 있습니다.

- 또 프로필 수정 로직 리팩토링과는 해당 문제가 관련이 없기에 리팩토링 로직도 엔티티와 도메인 분리하는 기존의 방식을 유지했습니다.
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
